### PR TITLE
miscellaneous small fixes

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -16,20 +16,22 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - run: pip install -U pip
+      - name: Install deps
+        run: |
+          python -m pip install -U pip
+          python -m pip install black black[jupyter]
+          python -m pip install isort
+          python -m pip install flake8-bugbear
+          python -m pip install mypy==0.982 types-setuptools types-requests numpy pytest
       - name: Python Black
         run: |
-          python -m pip install black black[jupyter]
           python -m black --check --diff .
       - name: Python isort
         run: |
-          python -m pip install isort
           python -m isort --check --diff .
       - name: Python style with flake8[bugbear]
         run: |
-          python -m pip install flake8-bugbear
           python -m flake8 .
       - name: Check type annotations mypy
         run: |
-          python -m pip install mypy==0.982 types-setuptools types-requests numpy
           python -m mypy .

--- a/api/python/cell_census/setup.cfg
+++ b/api/python/cell_census/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     numpy
     requests
     tiledb>=0.18.1
-    tiledbsoma>=0.5.0
+    tiledbsoma>=0.5.*
     typing_extensions
     s3fs
     scikit-misc

--- a/api/python/cell_census/src/cell_census/__init__.py
+++ b/api/python/cell_census/src/cell_census/__init__.py
@@ -1,14 +1,14 @@
 from .get_anndata import get_anndata
 from .open import download_source_h5ad, get_source_h5ad_uri, open_soma
-from .release_directory import get_directory, get_release_description
+from .release_directory import get_census_version_description, get_census_version_directory
 
 __version__ = "0.0.1-dev0"
 
 __all__ = [
     "download_source_h5ad",
     "get_anndata",
-    "get_directory",
+    "get_census_version_description",
+    "get_census_version_directory",
     "get_source_h5ad_uri",
-    "get_release_description",
     "open_soma",
 ]

--- a/api/python/cell_census/src/cell_census/experiment_query/query.py
+++ b/api/python/cell_census/src/cell_census/experiment_query/query.py
@@ -166,7 +166,8 @@ class ExperimentQuery:
         var_joinids = self._joinids["var"]
 
         if len(obs_joinids) == 0 or len(var_joinids) == 0:
-            return pa.Table.from_pylist([], schema=X.schema)
+            yield pa.Table.from_pylist([], schema=X.schema)
+            return
 
         if not prefetch:
             # yield for clarity

--- a/api/python/cell_census/src/cell_census/get_anndata.py
+++ b/api/python/cell_census/src/cell_census/get_anndata.py
@@ -26,6 +26,8 @@ ObsQuery = TypedDict(
         "suspension_type": Optional[Union[str, List[str]]],
         "tissue": Optional[Union[str, List[str]]],
         "tissue_ontology_term_id": Optional[Union[str, List[str]]],
+        "tissue_general": Optional[Union[str, List[str]]],
+        "tissue_general_ontology_term_id": Optional[Union[str, List[str]]],
     },
 )
 

--- a/api/python/cell_census/src/cell_census/open.py
+++ b/api/python/cell_census/src/cell_census/open.py
@@ -6,7 +6,7 @@ import s3fs
 import tiledb
 import tiledbsoma as soma
 
-from .release_directory import CensusLocator, CensusReleaseDescription, get_release_description
+from .release_directory import CensusLocator, CensusVersionDescription, get_census_version_description
 from .util import uri_join
 
 # TODO: temporary work-around for lack of contenxt/config in tiledbsoma.  Replace with soma
@@ -19,7 +19,7 @@ DEFAULT_TILEDB_CONFIGURATION = {
 }
 
 
-def _open_soma(description: CensusReleaseDescription) -> soma.Collection:
+def _open_soma(description: CensusVersionDescription) -> soma.Collection:
     locator = description["soma"]
     tiledb_config = {**DEFAULT_TILEDB_CONFIGURATION}
     s3_region = locator.get("s3_region", None)
@@ -30,19 +30,21 @@ def _open_soma(description: CensusReleaseDescription) -> soma.Collection:
 
 def open_soma(*, census_version: Optional[str] = "latest", uri: Optional[str] = None) -> soma.Collection:
     """
-    Open the Cell Census by version (name) or URI, returning a soma.Collection containing
-    the top-level census.  Raises error if census_versio is specified and unknown, or if
-    neither ``uri`` or ``census_version`` are specified.
+    Open the Cell Census by version or URI, returning a soma.Collection containing
+    the top-level census.  Raises error if census_version is specified and unknown, or if
+    neither ``uri`` or ``census_version`` are specified, or if the ``uri`` can not be
+    opened.
 
     TODO: add platform_config hook when it is further defined, allowing config overrides.
 
     Parameters
     ----------
     census_version : Optional[str]
-        The tag/name of the Census, e.g., "latest"
+        The version of the Census, e.g., "latest"
     uri : Optional[str]
         The URI containing the Census SOMA objects. If specified, will take precedence
-        over ``census_version`` parameter.
+        over ``census_version`` parameter. An exception will be raised if the URI can
+        not be opened.
 
     Returns
     -------
@@ -54,11 +56,14 @@ def open_soma(*, census_version: Optional[str] = "latest", uri: Optional[str] = 
 
     >>> census = cell_census.open_soma()
 
-    Open a specific Cell Census version by tag name:
+    Open a specific Cell Census by version:
     >>> census = cell_census.open_soma("2022-12-31")
 
-    Open a Cell Census by URI, rather than by version name:
-    >>> census = cell_census.open_soma(uri="cell-census")
+    Open a Cell Census by S3 URI, rather than by version.
+    >>> census = cell_census.open_soma(uri="s3://bucket/path")
+
+    Open a Cell Census by path (file:// URI), rather than by version.
+    >>> census = cell_census.open_soma(uri="/tmp/census")
     """
 
     if uri is not None:
@@ -67,7 +72,7 @@ def open_soma(*, census_version: Optional[str] = "latest", uri: Optional[str] = 
     if census_version is None:
         raise ValueError("Must specify either a cell census version or an explicit URI.")
 
-    description = get_release_description(census_version)  # raises
+    description = get_census_version_description(census_version)  # raises
     return _open_soma(description)
 
 
@@ -86,7 +91,7 @@ def get_source_h5ad_uri(dataset_id: str, *, census_version: str = "latest") -> C
 
     Returns
     -------
-    CensusLocator : the URI and optional S3 region for the sorce H5AD
+    CensusLocator : the URI and optional S3 region for the source H5AD
 
     Examples
     --------
@@ -94,7 +99,7 @@ def get_source_h5ad_uri(dataset_id: str, *, census_version: str = "latest") -> C
     {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/cb5efdb0-f91c-4cbd-9ad4-9d4fa41c572d.h5ad',
     's3_region': 'us-west-2'}
     """
-    description = get_release_description(census_version)  # raises
+    description = get_census_version_description(census_version)  # raises
     census = _open_soma(description)
     dataset = census["census_info"]["datasets"].read_as_pandas_all(value_filter=f"dataset_id == '{dataset_id}'")
     if len(dataset) == 0:
@@ -122,7 +127,7 @@ def download_source_h5ad(dataset_id: str, to_path: str, *, census_version: str =
     to_path : str
         The file name where the downloaded H5AD will be written.  Must not already exist.
     census_version : str
-        The census version tag. Defaults to ``latest``.
+        The census version name. Defaults to ``latest``.
 
     Returns
     -------

--- a/api/python/cell_census/src/cell_census/open.py
+++ b/api/python/cell_census/src/cell_census/open.py
@@ -71,7 +71,7 @@ def open_soma(*, census_version: Optional[str] = "latest", uri: Optional[str] = 
     return _open_soma(description)
 
 
-def get_source_h5ad_uri(dataset_id: str, *, census_version: Optional[str] = "latest") -> CensusLocator:
+def get_source_h5ad_uri(dataset_id: str, *, census_version: str = "latest") -> CensusLocator:
     """
     Open the named version of the census, and return the URI for the dataset_id.
     This does not guarantee that the H5AD exists or is accessible to the user.

--- a/api/python/cell_census/src/cell_census/open.py
+++ b/api/python/cell_census/src/cell_census/open.py
@@ -31,9 +31,34 @@ def _open_soma(description: CensusReleaseDescription) -> soma.Collection:
 def open_soma(*, census_version: Optional[str] = "latest", uri: Optional[str] = None) -> soma.Collection:
     """
     Open the Cell Census by version (name) or URI, returning a soma.Collection containing
-    the top-level census.
+    the top-level census.  Raises error if census_versio is specified and unknown, or if
+    neither ``uri`` or ``census_version`` are specified.
 
     TODO: add platform_config hook when it is further defined, allowing config overrides.
+
+    Parameters
+    ----------
+    census_version : Optional[str]
+        The tag/name of the Census, e.g., "latest"
+    uri : Optional[str]
+        The URI containing the Census SOMA objects. If specified, will take precedence
+        over ``census_version`` parameter.
+
+    Returns
+    -------
+    soma.Collection : returns a SOMA Collection object.
+
+    Examples
+    --------
+    Open the default Cell Census version:
+
+    >>> census = cell_census.open_soma()
+
+    Open a specific Cell Census version by tag name:
+    >>> census = cell_census.open_soma("2022-12-31")
+
+    Open a Cell Census by URI, rather than by version name:
+    >>> census = cell_census.open_soma(uri="cell-census")
     """
 
     if uri is not None:
@@ -46,13 +71,28 @@ def open_soma(*, census_version: Optional[str] = "latest", uri: Optional[str] = 
     return _open_soma(description)
 
 
-def get_source_h5ad_uri(dataset_id: str, *, census_version: str = "latest") -> CensusLocator:
+def get_source_h5ad_uri(dataset_id: str, *, census_version: Optional[str] = "latest") -> CensusLocator:
     """
     Open the named version of the census, and return the URI for the dataset_id.
-
     This does not guarantee that the H5AD exists or is accessible to the user.
+    Raises an error if dataset_id or census_version are unknown.
 
-    Raises if dataset_id or census_version are unknown.
+    Parameters
+    ----------
+    dataset_id : str
+        The dataset_id of interest
+    census_version : Optional[str]
+        The census version
+
+    Returns
+    -------
+    CensusLocator : the URI and optional S3 region for the sorce H5AD
+
+    Examples
+    --------
+    >>> cell_census.get_source_h5ad_uri("cb5efdb0-f91c-4cbd-9ad4-9d4fa41c572d")
+    {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/cb5efdb0-f91c-4cbd-9ad4-9d4fa41c572d.h5ad',
+    's3_region': 'us-west-2'}
     """
     description = get_release_description(census_version)  # raises
     census = _open_soma(description)

--- a/api/python/cell_census/src/cell_census/release_directory.py
+++ b/api/python/cell_census/src/cell_census/release_directory.py
@@ -19,8 +19,8 @@ CensusReleaseDescription = TypedDict(
     {
         "release_date": Optional[str],  # date of release, optional
         "release_build": str,  # date of build
-        "soma": CensusLocator,
-        "h5ads": CensusLocator,
+        "soma": CensusLocator,  # SOMA objects locator
+        "h5ads": CensusLocator,  # source H5ADs locator
     },
 )
 CensusDirectory = Dict[CensusReleaseTag, Union[CensusReleaseTag, CensusReleaseDescription]]
@@ -31,7 +31,34 @@ CELL_CENSUS_RELEASE_DIRECTORY_URL = "https://s3.us-west-2.amazonaws.com/cellxgen
 
 
 def get_release_description(tag: str) -> CensusReleaseDescription:
-    """Get release description for given tag. Raises KeyError if unknown tag value."""
+    """
+    Get release description for given tag from the Cell Census release directory.
+    Raises KeyError if unknown tag value.
+
+    Parameters
+    ----------
+    tag : str
+        The release tag or name.
+
+    Returns
+    -------
+    CensusReleaseDescription
+        Dictionary containing a description of the release.
+
+    See Also
+    --------
+    get_directory : returns the entire directory as a dict.
+
+    Examples
+    --------
+    >>> cell_census.get_release_description("latest")
+    {'release_date': None,
+    'release_build': '2022-12-01',
+    'soma': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/soma/',
+    's3_region': 'us-west-2'},
+    'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/',
+    's3_region': 'us-west-2'}}
+    """
     census_directory = get_directory()
     description = census_directory.get(tag, None)
     if description is None:
@@ -41,7 +68,43 @@ def get_release_description(tag: str) -> CensusReleaseDescription:
 
 def get_directory() -> Dict[CensusReleaseTag, CensusReleaseDescription]:
     """
-    Get the directory of cell census releases available.
+    Get the directory of cell census releases currently available.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    Dict[CensusReleaseTag, CensusReleaseDescription]
+        Dictionary of release tags (names) and their corresponding
+        release description.
+
+    See Also
+    --------
+    get_release_description : get release description by tag.
+
+    Examples
+    --------
+    >>> cell_census.get_directory()
+    {'latest': {'release_date': None,
+    'release_build': '2022-12-01',
+    'soma': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/soma/',
+    's3_region': 'us-west-2'},
+    'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/',
+    's3_region': 'us-west-2'}},
+    '2022-12-01': {'release_date': None,
+    'release_build': '2022-12-01',
+    'soma': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/soma/',
+    's3_region': 'us-west-2'},
+    'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/',
+    's3_region': 'us-west-2'}},
+    '2022-11-29': {'release_date': None,
+    'release_build': '2022-11-29',
+    'soma': {'uri': 's3://cellxgene-data-public/cell-census/2022-11-29/soma/',
+    's3_region': 'us-west-2'},
+    'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2022-11-29/h5ads/',
+    's3_region': 'us-west-2'}}}
     """
     response = requests.get(CELL_CENSUS_RELEASE_DIRECTORY_URL)
     response.raise_for_status()

--- a/api/python/cell_census/tests/test_directory.py
+++ b/api/python/cell_census/tests/test_directory.py
@@ -39,8 +39,8 @@ def directory_mock(requests_mock: rm.Mocker) -> Any:
     return requests_mock.get(CELL_CENSUS_RELEASE_DIRECTORY_URL, json=DIRECTORY_JSON)
 
 
-def test_get_directory(directory_mock: Any) -> None:
-    directory = cell_census.get_directory()
+def test_get_census_version_directory(directory_mock: Any) -> None:
+    directory = cell_census.get_census_version_directory()
 
     assert isinstance(directory, dict)
     assert len(directory) > 0
@@ -55,4 +55,4 @@ def test_get_directory(directory_mock: Any) -> None:
     assert directory["latest"] == directory["2022-11-01"]
 
     for tag in directory:
-        assert directory[tag] == cell_census.get_release_description(tag)
+        assert directory[tag] == cell_census.get_census_version_description(tag)

--- a/api/python/cell_census/tests/test_directory.py
+++ b/api/python/cell_census/tests/test_directory.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+import cell_census
+import pytest
+import requests_mock as rm
+from cell_census.release_directory import CELL_CENSUS_RELEASE_DIRECTORY_URL
+
+DIRECTORY_JSON = {
+    "latest": "2022-11-01",
+    "2022-11-01": {
+        "release_date": "2022-11-30",
+        "release_build": "2022-11-01",
+        "soma": {
+            "uri": "s3://cellxgene-data-public/cell-census/2022-11-01/soma/",
+            "s3_region": "us-west-2",
+        },
+        "h5ads": {
+            "uri": "s3://cellxgene-data-public/cell-census/2022-11-01/h5ads/",
+            "s3_region": "us-west-2",
+        },
+    },
+    "2022-10-01": {
+        "release_date": "2022-10-30",
+        "release_build": "2022-10-01",
+        "soma": {
+            "uri": "s3://cellxgene-data-public/cell-census/2022-10-01/soma/",
+            "s3_region": "us-west-2",
+        },
+        "h5ads": {
+            "uri": "s3://cellxgene-data-public/cell-census/2022-10-01/h5ads/",
+            "s3_region": "us-west-2",
+        },
+    },
+}
+
+
+@pytest.fixture
+def directory_mock(requests_mock: rm.Mocker) -> Any:
+    return requests_mock.get(CELL_CENSUS_RELEASE_DIRECTORY_URL, json=DIRECTORY_JSON)
+
+
+def test_get_directory(directory_mock: Any) -> None:
+    directory = cell_census.get_directory()
+
+    assert isinstance(directory, dict)
+    assert len(directory) > 0
+    assert all((type(k) == str for k in directory.keys()))
+    assert all((type(v) == dict for v in directory.values()))
+
+    for tag in DIRECTORY_JSON:
+        assert tag in directory
+        if isinstance(DIRECTORY_JSON[tag], dict):
+            assert directory[tag] == DIRECTORY_JSON[tag]
+
+    assert directory["latest"] == directory["2022-11-01"]
+
+    for tag in directory:
+        assert directory[tag] == cell_census.get_release_description(tag)

--- a/api/python/cell_census/tests/test_util.py
+++ b/api/python/cell_census/tests/test_util.py
@@ -1,0 +1,20 @@
+from cell_census.util import uri_join
+
+
+def test_uri_join() -> None:
+
+    assert uri_join("https://foo/", "bar") == "https://foo/bar"
+    assert uri_join("https://foo/a", "bar") == "https://foo/bar"
+    assert uri_join("https://foo/a/", "bar") == "https://foo/a/bar"
+    assert uri_join("https://foo/", "a/b") == "https://foo/a/b"
+    assert uri_join("https://foo/", "a/b/") == "https://foo/a/b/"
+
+    assert uri_join("https://foo/?a=b#99", "a?b=c#1") == "https://foo/a?b=c#1"
+
+    assert uri_join("http://foo/bar/", "a") == "http://foo/bar/a"
+    assert uri_join("https://foo/bar/", "a") == "https://foo/bar/a"
+    assert uri_join("s3://foo/bar/", "a") == "s3://foo/bar/a"
+    assert uri_join("foo/bar", "a") == "foo/a"
+    assert uri_join("/foo/bar", "a") == "/foo/a"
+    assert uri_join("file://foo/bar", "a") == "file://foo/a"
+    assert uri_join("file:///foo/bar", "a") == "file:///foo/a"

--- a/cell_census_builder/experiment_builder.py
+++ b/cell_census_builder/experiment_builder.py
@@ -413,6 +413,7 @@ def _accumulate_all_X_layers(
             col = local_var_joinids[X.col]
             assert (col >= 0).all()
             X_remap = sparse.coo_array((X.data, (row, col)), shape=(eb.n_obs, eb.n_var))
+            X_remap.eliminate_zeros()
             se.ms[ms_name].X[layer_name].write_sparse_tensor(pa.SparseCOOTensor.from_scipy(X_remap))
             gc.collect()
 

--- a/cell_census_builder/validate.py
+++ b/cell_census_builder/validate.py
@@ -6,7 +6,7 @@ import os.path
 import pathlib
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Tuple, Union, cast
+from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt

--- a/cell_census_builder/validate.py
+++ b/cell_census_builder/validate.py
@@ -259,18 +259,20 @@ def _validate_X_layers_contents(args: Tuple[str, str, Dataset, List[ExperimentBu
 
             raw_nnz = count_elements(se.ms["RNA"].X["raw"], soma_joinids)
 
-        def nnz(arr: Union[sparse.spmatrix, npt.NDArray[Any]]) -> int:
+        def count_nonzero(arr: Union[sparse.spmatrix, npt.NDArray[Any]]) -> int:
             """Return _actual_ non-zero count, NOT the stored value count."""
             if isinstance(arr, (sparse.spmatrix, sparse.coo_array, sparse.csr_array, sparse.csc_array)):
                 return np.count_nonzero(arr.data)
             return np.count_nonzero(arr)
 
         if ad.raw is None:
-            assert raw_nnz == nnz(ad.X), f"{eb.name}:{dataset.dataset_id} 'raw' nnz mismatch {raw_nnz} vs {nnz(ad.X)}"
+            assert raw_nnz == count_nonzero(
+                ad.X
+            ), f"{eb.name}:{dataset.dataset_id} 'raw' nnz mismatch {raw_nnz} vs {count_nonzero(ad.X)}"
         else:
-            assert raw_nnz == nnz(
+            assert raw_nnz == count_nonzero(
                 ad.raw.X
-            ), f"{eb.name}:{dataset.dataset_id} 'raw' nnz mismatch {raw_nnz} vs {nnz(ad.raw.X)}"
+            ), f"{eb.name}:{dataset.dataset_id} 'raw' nnz mismatch {raw_nnz} vs {count_nonzero(ad.raw.X)}"
 
     return True
 

--- a/cell_census_builder/validate.py
+++ b/cell_census_builder/validate.py
@@ -231,7 +231,9 @@ def _validate_X_layers_contents(args: Tuple[str, str, Dataset, List[ExperimentBu
     Validate that a single dataset is correctly represented in the census.
     Intended to be dispatched from validate_X_layers.
 
-    Currently implements a weak test: that nnz is correct.
+    Currently implements weak tests:
+    * the nnz is correct
+    * there are no zeros explicitly saved (this is mandated by cell census schema)
     """
     assets_path, soma_path, dataset, experiment_builders = args
     census = soma.Collection(soma_path, ctx=TileDB_Ctx())
@@ -258,8 +260,9 @@ def _validate_X_layers_contents(args: Tuple[str, str, Dataset, List[ExperimentBu
             raw_nnz = count_elements(se.ms["RNA"].X["raw"], soma_joinids)
 
         def nnz(arr: Union[sparse.spmatrix, npt.NDArray[Any]]) -> int:
+            """Return _actual_ non-zero count, NOT the stored value count."""
             if isinstance(arr, (sparse.spmatrix, sparse.coo_array, sparse.csr_array, sparse.csc_array)):
-                return cast(int, arr.nnz)
+                return np.count_nonzero(arr.data)
             return np.count_nonzero(arr)
 
         if ad.raw is None:


### PR DESCRIPTION
Changes:
* missing yield causes get_anndata to fail on empty query.  Change made to experiment_query.query.py.  Fixes #26
* cell-census schema requires no explicitly stored zeros. Add code to enforce _and_ validate this.  Fixes #23 
* add a couple of small unit tests to kick-start efforts to build full set of unit tests. A start at #9   Includes change to formatting.yml GH Action definition required to perform static type analysis on the unit tests.
* add docstrings to cell_census pubilc API.  Fixes #15 
* add missing type declaration for new tissue_general columns. Fixes #20 
* Fixed cell_census package dependencies to allow for the _pre-release_ version of tiledbsoma