### PR TITLE
schema performance tuning

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -34,4 +34,7 @@ jobs:
           python -m flake8 .
       - name: Check type annotations mypy
         run: |
-          python -m mypy .
+          # cell_census_builder is Python 3.9+
+          # cell_census package is Python 3.7+
+          python -m mypy --python-version 3.9 ./cell_census_builder
+          python -m mypy --python-version 3.7 ./api

--- a/api/python/cell_census/setup.cfg
+++ b/api/python/cell_census/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.10
 
 [options]
-python_requires = >= 3.7
+python_requires = >= 3.7, < 3.11
 install_requires =
     numba
     numpy

--- a/api/python/cell_census/setup.cfg
+++ b/api/python/cell_census/setup.cfg
@@ -17,12 +17,13 @@ classifiers =
     Operating System :: Unix
     Operating System :: POSIX :: Linux
     Operating System :: MacOS :: MacOS X
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
 
 [options]
-python_requires = >= 3.8
+python_requires = >= 3.7
 install_requires =
     numba
     numpy

--- a/api/python/cell_census/src/cell_census/compute/meanvar.py
+++ b/api/python/cell_census/src/cell_census/compute/meanvar.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import numba
 import numpy as np
 import numpy.typing as npt
@@ -25,7 +27,7 @@ class OnlineMatrixMeanVariance:
     def update(self, coord_vec: npt.NDArray[np.int64], value_vec: npt.NDArray[np.float32]) -> None:
         _mean_variance_update(coord_vec, value_vec, self.n_a, self.u_a, self.M2_a)
 
-    def finalize(self) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    def finalize(self) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
         """
         Returns tuple containing mean and variance
         """
@@ -63,7 +65,7 @@ def _mean_variance_update(
 @numba.jit(nopython=True, nogil=True)  # type: ignore[misc]  # See https://github.com/numba/numba/issues/7424
 def _mean_variance_finalize(
     n_samples: int, n_a: npt.NDArray[np.int32], u_a: npt.NDArray[np.float64], M2_a: npt.NDArray[np.float64]
-) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """
     Finalize incremental values, acconting for missing elements (due to sparse input).
     Non-sparse and sparse combined using Chan's parallel adaptation of Welford's.

--- a/api/python/cell_census/src/cell_census/experiment_query/axis.py
+++ b/api/python/cell_census/src/cell_census/experiment_query/axis.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
-from typing import Optional, Tuple, TypedDict, Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
+from typing_extensions import TypedDict
 
 # Type declaration/helpers local to this file
 #

--- a/api/python/cell_census/src/cell_census/experiment_query/query.py
+++ b/api/python/cell_census/src/cell_census/experiment_query/query.py
@@ -7,13 +7,13 @@ from contextlib import contextmanager
 from typing import (
     AsyncIterator,
     Callable,
+    Dict,
     Generator,
     Iterator,
     List,
-    Literal,
     Optional,
     Sequence,
-    TypedDict,
+    Tuple,
     TypeVar,
     Union,
     cast,
@@ -25,7 +25,7 @@ import numpy.typing as npt
 import pandas as pd
 import pyarrow as pa
 import tiledbsoma as soma
-from typing_extensions import ParamSpec
+from typing_extensions import Literal, ParamSpec, TypedDict
 
 from .anndata import make_anndata
 from .axis import AxisQuery, MatrixAxisQuery
@@ -278,7 +278,7 @@ class ExperimentQuery:
         query_result = self.read(X_name, column_names=column_names, X_layers=X_layers, use_position_indexing=True)
         return make_anndata(query_result)
 
-    def _rewrite_X_for_positional_indexing(self, X_tables: dict[str, pa.Table]) -> dict[str, pa.Table]:
+    def _rewrite_X_for_positional_indexing(self, X_tables: Dict[str, pa.Table]) -> Dict[str, pa.Table]:
         """
         This is a private convenience function to convert axis dataframe to X matrix joins
         from `soma_joinid`-based joins to positionally indexed joins (like AnnData uses).
@@ -391,7 +391,7 @@ async def async_iter(gen: Generator[T, None, None]) -> AsyncIterator[T]:
         yield value
 
 
-def wrap_generator(gen: Generator[T, None, None]) -> Callable[[], tuple[Optional[T], bool]]:
+def wrap_generator(gen: Generator[T, None, None]) -> Callable[[], Tuple[Optional[T], bool]]:
     """
     Wrap a generator, making it a "normal" function that is amenable
     to running in a thread. Each time it is called, it returns a
@@ -401,7 +401,7 @@ def wrap_generator(gen: Generator[T, None, None]) -> Callable[[], tuple[Optional
     """
     assert inspect.isgenerator(gen)
 
-    def _next() -> tuple[Optional[T], bool]:
+    def _next() -> Tuple[Optional[T], bool]:
         try:
             value = next(gen)
             return value, False

--- a/api/python/cell_census/src/cell_census/experiment_query/types.py
+++ b/api/python/cell_census/src/cell_census/experiment_query/types.py
@@ -1,10 +1,11 @@
 """
 Types global to this module
 """
-from typing import Optional, Sequence, TypedDict
+from typing import Dict, Optional, Sequence
 
 import pandas as pd
 import pyarrow as pa
+from typing_extensions import TypedDict
 
 # Sadly, you can't define a generic TypedDict....
 
@@ -13,14 +14,14 @@ class ExperimentQueryReadArrowResult(TypedDict, total=False):
     obs: pa.Table
     var: pa.Table
     X: pa.Table
-    X_layers: dict[str, pa.Table]
+    X_layers: Dict[str, pa.Table]
 
 
 class ExperimentQueryReadPandasResult(TypedDict, total=False):
     obs: pd.DataFrame
     var: pd.DataFrame
     X: pd.DataFrame
-    X_layers: dict[str, pd.DataFrame]
+    X_layers: Dict[str, pd.DataFrame]
 
 
 AxisColumnNames = TypedDict(

--- a/api/python/cell_census/src/cell_census/get_anndata.py
+++ b/api/python/cell_census/src/cell_census/get_anndata.py
@@ -1,9 +1,10 @@
 import numbers
 import re
-from typing import List, Optional, TypedDict, Union
+from typing import List, Optional, Union
 
 import anndata
 import tiledbsoma as soma
+from typing_extensions import TypedDict
 
 from .experiment_query import AxisColumnNames, AxisQuery, experiment_query
 

--- a/api/python/cell_census/src/cell_census/release_directory.py
+++ b/api/python/cell_census/src/cell_census/release_directory.py
@@ -1,6 +1,7 @@
-from typing import Dict, Optional, TypedDict, Union, cast
+from typing import Dict, Optional, Union, cast
 
 import requests
+from typing_extensions import TypedDict
 
 """
 The following types describe the expected directory of Cell Census builds, used

--- a/cell_census_builder/REAMDE.md
+++ b/cell_census_builder/REAMDE.md
@@ -8,6 +8,7 @@ CAVEATS (READ THIS):
 
 1. The code is written to the still-rapidly-evolving and **pre-release** Python SOMA API, _and will be subject to change_ as the SOMA API and `tiledbsoma` evolve and stabilize.
 2. The schema implemented by this code is still evolving and subject to change.
+3. The `cell_census_builder` package requires Python 3.9 or later.
 
 ## Usage
 

--- a/cell_census_builder/__main__.py
+++ b/cell_census_builder/__main__.py
@@ -136,7 +136,7 @@ def build(
     create_census_summary(top_level_collection["census_info"], experiment_builders, args.build_tag)
 
     if args.consolidate:
-        consolidate(top_level_collection.uri)
+        consolidate(args, top_level_collection.uri)
 
     return 0
 

--- a/cell_census_builder/anndata.py
+++ b/cell_census_builder/anndata.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Iterator, List, Optional, Protocol, TypedDict, Union
+from typing import Any, Iterator, List, Optional, Protocol, Tuple, TypedDict, Union
 
 import anndata
 import numpy as np
@@ -20,7 +20,7 @@ AnnDataFilterSpec = TypedDict(
 
 def open_anndata(
     base_path: str, datasets: Union[List[Dataset], Dataset], *args: Any, **kwargs: Any
-) -> Iterator[tuple[Dataset, anndata.AnnData]]:
+) -> Iterator[Tuple[Dataset, anndata.AnnData]]:
     """
     Generator to open anndata in a given mode, and filter out those H5ADs which do not match our base
     criteria for inclusion in the census.

--- a/cell_census_builder/consolidate.py
+++ b/cell_census_builder/consolidate.py
@@ -31,7 +31,7 @@ def consolidate(args: argparse.Namespace, uri: str) -> None:
 
 def consolidate_collection(
     args: argparse.Namespace, collection: soma.Collection, ppe: concurrent.futures.ProcessPoolExecutor
-) -> List[concurrent.futures.Future]:
+) -> List[concurrent.futures.Future[str]]:
     futures = []
     for soma_obj in collection.values():
         type = soma_obj.soma_type

--- a/cell_census_builder/consolidate.py
+++ b/cell_census_builder/consolidate.py
@@ -1,12 +1,16 @@
+import argparse
+import concurrent.futures
 import logging
 
 import tiledbsoma as soma
+
+from .mp import create_process_pool_executor
 
 if soma.get_storage_engine() == "tiledb":
     import tiledb
 
 
-def consolidate(uri: str) -> None:
+def consolidate(args: argparse.Namespace, uri: str) -> None:
     """
     This is a non-portable, TileDB-specific consolidation routine.
     """
@@ -17,21 +21,29 @@ def consolidate(uri: str) -> None:
     if not census.exists():
         return
 
-    consolidate_collection(census)
+    consolidate_collection(args, census)
 
 
-def consolidate_collection(collection: soma.Collection) -> None:
-    for soma_obj in collection.values():
-        type = soma_obj.soma_type
-        if type in ["SOMADataFrame", "SOMASparseNdArray", "SOMADenseNdArray"]:
-            logging.info(f"Consolidating {type} {soma_obj.uri}")
-            consolidate_tiledb_object(soma_obj.uri)
-        elif type in ["SOMACollection", "SOMAExperiment", "SOMAMeasurement"]:
-            consolidate_collection(soma_obj)
-        else:
-            raise TypeError(f"Unknown SOMA type {type}.")
+def consolidate_collection(args: argparse.Namespace, collection: soma.Collection) -> None:
+
+    futures = []
+    with create_process_pool_executor(args, max_workers=4) as ppe:
+        for soma_obj in collection.values():
+            type = soma_obj.soma_type
+            if type in ["SOMADataFrame", "SOMASparseNdArray", "SOMADenseNdArray"]:
+                logging.info(f"Consolidate: starting {type} {soma_obj.uri}")
+                futures.append(ppe.submit(consolidate_tiledb_object, soma_obj.uri))
+            elif type in ["SOMACollection", "SOMAExperiment", "SOMAMeasurement"]:
+                consolidate_collection(args, soma_obj)
+            else:
+                raise TypeError(f"Unknown SOMA type {type}.")
+
+        for future in concurrent.futures.as_completed(futures):
+            uri = future.result()
+            logging.info(f"Consolidate: completed {uri}")
 
 
-def consolidate_tiledb_object(uri: str) -> None:
+def consolidate_tiledb_object(uri: str) -> str:
     tiledb.consolidate(uri, config=tiledb.Config({"sm.consolidation.buffer_size": 1 * 1024**3}))
     tiledb.vacuum(uri)
+    return uri

--- a/cell_census_builder/experiment_builder.py
+++ b/cell_census_builder/experiment_builder.py
@@ -290,7 +290,7 @@ class ExperimentBuilder:
                 snda = soma.SparseNdArray(uricat(measurement.X.uri, layer_name), ctx=TileDB_Ctx()).create(
                     CENSUS_X_LAYERS[layer_name],
                     (self.n_obs, self.n_var),
-                    platform_config=CENSUS_X_LAYERS_PLATFORM_CONFIG,
+                    platform_config=CENSUS_X_LAYERS_PLATFORM_CONFIG[layer_name],
                 )
                 measurement.X.set(layer_name, snda, relative=True)
 

--- a/cell_census_builder/experiment_builder.py
+++ b/cell_census_builder/experiment_builder.py
@@ -4,7 +4,7 @@ import gc
 import io
 import logging
 from enum import IntEnum
-from typing import List, Optional, Sequence, Tuple, TypedDict, Union, overload
+from typing import Dict, List, Optional, Sequence, Tuple, TypedDict, Union, overload
 
 import anndata
 import numpy as np
@@ -48,8 +48,8 @@ from .util import (
 #
 # TODO: convert this to a dataclass or namedtuple.
 #
-PresenceResult = tuple[str, int, str, npt.NDArray[np.bool_], npt.NDArray[np.int64]]
-PresenceResults = tuple[PresenceResult, ...]
+PresenceResult = Tuple[str, int, str, npt.NDArray[np.bool_], npt.NDArray[np.int64]]
+PresenceResults = Tuple[PresenceResult, ...]
 
 # UBERON tissue term mapper
 tissue_mapper: TissueMapper = TissueMapper()
@@ -100,9 +100,9 @@ class ExperimentBuilder:
         self.n_datasets: int = 0
         self.n_donors: int = 0  # Caution: defined as (unique dataset_id, donor_id) tuples, *excluding* some values
         self.var_df: pd.DataFrame = pd.DataFrame(columns=["feature_id", "feature_name"])
-        self.dataset_obs_joinid_start: dict[str, int]
+        self.dataset_obs_joinid_start: Dict[str, int]
         self.census_summary_cell_counts = init_summary_counts_accumulator()
-        self.presence: dict[int, tuple[npt.NDArray[np.bool_], npt.NDArray[np.int64]]] = {}
+        self.presence: Dict[int, Tuple[npt.NDArray[np.bool_], npt.NDArray[np.int64]]] = {}
         self.build_state = ExperimentBuilder.BuildState.Initialized
 
         self.load_assets()
@@ -288,7 +288,7 @@ class ExperimentBuilder:
             measurement = se.ms["RNA"]
             for layer_name in CENSUS_X_LAYERS:
                 snda = soma.SparseNdArray(uricat(measurement.X.uri, layer_name), ctx=TileDB_Ctx()).create(
-                    pa.float32(),
+                    CENSUS_X_LAYERS[layer_name],
                     (self.n_obs, self.n_var),
                     platform_config=CENSUS_X_LAYERS_PLATFORM_CONFIG,
                 )
@@ -552,7 +552,7 @@ def populate_X_layers(
 class SummaryStats(TypedDict):
     total_cell_count: int
     unique_cell_count: int
-    number_donors: dict[str, int]
+    number_donors: Dict[str, int]
 
 
 def get_summary_stats(experiment_builders: Sequence[ExperimentBuilder]) -> SummaryStats:

--- a/cell_census_builder/globals.py
+++ b/cell_census_builder/globals.py
@@ -64,16 +64,69 @@ CENSUS_OBS_TERM_COLUMNS = {
     "tissue_general_ontology_term_id": pa.large_string(),
 }
 
+_RepetativeStringLabelObs = [
+    # these columns are highly repetative string lables and will have appropriate filter
+    "assay",
+    "assay_ontology_term_id",
+    "cell_type",
+    "cell_type_ontology_term_id",
+    "dataset_id",
+    "development_stage",
+    "development_stage_ontology_term_id",
+    "disease",
+    "disease_ontology_term_id",
+    "donor_id",
+    "self_reported_ethnicity",
+    "self_reported_ethnicity_ontology_term_id",
+    "sex",
+    "sex_ontology_term_id",
+    "suspension_type",
+    "tissue",
+    "tissue_ontology_term_id",
+    "tissue_general",
+    "tissue_general_ontology_term_id",
+]
+CENSUS_OBS_PLATFORM_CONFIG = {
+    "tiledb": {
+        "create": {
+            "capacity": 2**18,
+            "dims": {"soma_joinid": {"filters": ["DoubleDeltaFilter", "ZstdFilter"]}},
+            "attrs": {
+                **{k: {"filters": ["DictionaryFilter", "ZstdFilter"]} for k in _RepetativeStringLabelObs},
+            },
+        }
+    }
+}
+
 CENSUS_VAR_TERM_COLUMNS = {
     "soma_joinid": pa.int64(),
     "feature_id": pa.large_string(),
     "feature_name": pa.large_string(),
     "feature_length": pa.int64(),
 }
+CENSUS_VAR_PLATFORM_CONFIG = {
+    "tiledb": {
+        "create": {
+            "dims": {"soma_joinid": {"filters": ["DoubleDeltaFilter", "ZstdFilter"]}},
+        }
+    }
+}
 
-X_LAYERS = [
+CENSUS_X_LAYERS = [
     "raw",
 ]
+CENSUS_X_LAYERS_PLATFORM_CONFIG = {
+    "tiledb": {
+        "create": {
+            "capacity": 2**18,
+            "dims": {
+                "soma_dim_0": {"filters": ["ByteShuffleFilter", "ZstdFilter"]},
+                "soma_dim_1": {"filters": ["ByteShuffleFilter", "ZstdFilter"]},
+            },
+            "attrs": {"soma_data": {"filters": ["ByteShuffleFilter", "ZstdFilter"]}},
+        }
+    }
+}
 
 # list of EFO terms that correspond to RNA seq modality/measurement
 RNA_SEQ = [

--- a/cell_census_builder/globals.py
+++ b/cell_census_builder/globals.py
@@ -65,7 +65,7 @@ CENSUS_OBS_TERM_COLUMNS = {
 }
 
 _RepetativeStringLabelObs = [
-    # these columns are highly repetative string lables and will have appropriate filter
+    # these columns are highly repetative string labels and will have appropriate filter
     "assay",
     "assay_ontology_term_id",
     "cell_type",

--- a/cell_census_builder/globals.py
+++ b/cell_census_builder/globals.py
@@ -89,11 +89,15 @@ _RepetativeStringLabelObs = [
 CENSUS_OBS_PLATFORM_CONFIG = {
     "tiledb": {
         "create": {
-            "capacity": 2**18,
-            "dims": {"soma_joinid": {"filters": ["DoubleDeltaFilter", "ZstdFilter"]}},
+            "capacity": 2**16,
+            "dims": {"soma_joinid": {"filters": ["DoubleDeltaFilter", {"_type": "ZstdFilter", "level": 5}]}},
             "attrs": {
-                **{k: {"filters": ["DictionaryFilter", "ZstdFilter"]} for k in _RepetativeStringLabelObs},
+                **{
+                    k: {"filters": ["DictionaryFilter", {"_type": "ZstdFilter", "level": 5}]}
+                    for k in _RepetativeStringLabelObs
+                },
             },
+            "offsets_filters": ["DoubleDeltaFilter", {"_type": "ZstdFilter", "level": 5}],
         }
     }
 }
@@ -107,7 +111,9 @@ CENSUS_VAR_TERM_COLUMNS = {
 CENSUS_VAR_PLATFORM_CONFIG = {
     "tiledb": {
         "create": {
-            "dims": {"soma_joinid": {"filters": ["DoubleDeltaFilter", "ZstdFilter"]}},
+            "capacity": 2**16,
+            "dims": {"soma_joinid": {"filters": ["DoubleDeltaFilter", {"_type": "ZstdFilter", "level": 5}]}},
+            "offsets_filters": ["DoubleDeltaFilter", {"_type": "ZstdFilter", "level": 5}],
         }
     }
 }
@@ -116,14 +122,17 @@ CENSUS_X_LAYERS = [
     "raw",
 ]
 CENSUS_X_LAYERS_PLATFORM_CONFIG = {
+    # This should be configured per layer, once there is >1 layer
     "tiledb": {
         "create": {
-            "capacity": 2**18,
+            "capacity": 2**16,
             "dims": {
-                "soma_dim_0": {"filters": ["ByteShuffleFilter", "ZstdFilter"]},
-                "soma_dim_1": {"filters": ["ByteShuffleFilter", "ZstdFilter"]},
+                "soma_dim_0": {"tile": 2048, "filters": [{"_type": "ZstdFilter", "level": 5}]},
+                "soma_dim_1": {"tile": 2048, "filters": ["ByteShuffleFilter", {"_type": "ZstdFilter", "level": 5}]},
             },
-            "attrs": {"soma_data": {"filters": ["ByteShuffleFilter", "ZstdFilter"]}},
+            "attrs": {"soma_data": {"filters": ["ByteShuffleFilter", {"_type": "ZstdFilter", "level": 5}]}},
+            "cell_order": "row-major",
+            "tile_order": "row-major",
         }
     }
 }

--- a/cell_census_builder/globals.py
+++ b/cell_census_builder/globals.py
@@ -68,13 +68,14 @@ CENSUS_OBS_TERM_COLUMNS = {
 Materialization of obs/var schema in TileDB is tuned with the following, largely informed by empirical testing:
 * string columns with repeating labels use DictionaryFilter, which efficiently encodes these highly repetative strings.
   Columns with non-repetative values (e.g., var.feature_id) are NOT dictionary coded.
-* obs/var DataFrame show significant improvement in on-disk size and read performance at high Zstd compression level, 
-  making it worth the extra build/write compute time. Level set to highest value that does not require additional resources
-  at decompression (nb. 20+ requres additional memory).
+* obs/var DataFrame show significant improvement in on-disk size and read performance at high Zstd compression level,
+  making it worth the extra build/write compute time. Level set to highest value that does not require additional
+  resources at decompression (nb. 20+ requres additional memory).
 * int64 index columns (soma_joinid, soma_dim_0, etc) empirically show wins from ByteShuffle followed by Zstd.
   First dimension of axis dataframes are always monotonically increasing, and also beneit from DoubleDelta.
-* Benchmarking X slicing (using lung demo notebook) used to tune X[raw]. Read / query performance did not benefit from 
-  higher Zstd compression beyond level=5, so the level was not increased further (and level=5 is still reasonable for writes)
+* Benchmarking X slicing (using lung demo notebook) used to tune X[raw]. Read / query performance did not benefit from
+  higher Zstd compression beyond level=5, so the level was not increased further (and level=5 is still reasonable for
+  writes)
 """
 
 _RepetativeStringLabelObs = [

--- a/cell_census_builder/globals.py
+++ b/cell_census_builder/globals.py
@@ -118,21 +118,22 @@ CENSUS_VAR_PLATFORM_CONFIG = {
     }
 }
 
-CENSUS_X_LAYERS = [
-    "raw",
-]
+CENSUS_X_LAYERS = {
+    "raw": pa.float32(),
+}
 CENSUS_X_LAYERS_PLATFORM_CONFIG = {
-    # This should be configured per layer, once there is >1 layer
-    "tiledb": {
-        "create": {
-            "capacity": 2**16,
-            "dims": {
-                "soma_dim_0": {"tile": 2048, "filters": [{"_type": "ZstdFilter", "level": 5}]},
-                "soma_dim_1": {"tile": 2048, "filters": ["ByteShuffleFilter", {"_type": "ZstdFilter", "level": 5}]},
-            },
-            "attrs": {"soma_data": {"filters": ["ByteShuffleFilter", {"_type": "ZstdFilter", "level": 5}]}},
-            "cell_order": "row-major",
-            "tile_order": "row-major",
+    "raw": {
+        "tiledb": {
+            "create": {
+                "capacity": 2**16,
+                "dims": {
+                    "soma_dim_0": {"tile": 2048, "filters": [{"_type": "ZstdFilter", "level": 5}]},
+                    "soma_dim_1": {"tile": 2048, "filters": ["ByteShuffleFilter", {"_type": "ZstdFilter", "level": 5}]},
+                },
+                "attrs": {"soma_data": {"filters": ["ByteShuffleFilter", {"_type": "ZstdFilter", "level": 5}]}},
+                "cell_order": "row-major",
+                "tile_order": "row-major",
+            }
         }
     }
 }

--- a/cell_census_builder/globals.py
+++ b/cell_census_builder/globals.py
@@ -64,6 +64,19 @@ CENSUS_OBS_TERM_COLUMNS = {
     "tissue_general_ontology_term_id": pa.large_string(),
 }
 
+"""
+Materialization of obs/var schema in TileDB is tuned with the following, largely informed by empirical testing:
+* string columns with repeating labels use DictionaryFilter, which efficiently encodes these highly repetative strings.
+  Columns with non-repetative values (e.g., var.feature_id) are NOT dictionary coded.
+* obs/var DataFrame show significant improvement in on-disk size and read performance at high Zstd compression level, 
+  making it worth the extra build/write compute time. Level set to highest value that does not require additional resources
+  at decompression (nb. 20+ requres additional memory).
+* int64 index columns (soma_joinid, soma_dim_0, etc) empirically show wins from ByteShuffle followed by Zstd.
+  First dimension of axis dataframes are always monotonically increasing, and also beneit from DoubleDelta.
+* Benchmarking X slicing (using lung demo notebook) used to tune X[raw]. Read / query performance did not benefit from 
+  higher Zstd compression beyond level=5, so the level was not increased further (and level=5 is still reasonable for writes)
+"""
+
 _RepetativeStringLabelObs = [
     # these columns are highly repetative string labels and will have appropriate filter
     "assay",

--- a/cell_census_builder/globals.py
+++ b/cell_census_builder/globals.py
@@ -90,14 +90,14 @@ CENSUS_OBS_PLATFORM_CONFIG = {
     "tiledb": {
         "create": {
             "capacity": 2**16,
-            "dims": {"soma_joinid": {"filters": ["DoubleDeltaFilter", {"_type": "ZstdFilter", "level": 5}]}},
+            "dims": {"soma_joinid": {"filters": ["DoubleDeltaFilter", {"_type": "ZstdFilter", "level": 19}]}},
             "attrs": {
                 **{
-                    k: {"filters": ["DictionaryFilter", {"_type": "ZstdFilter", "level": 5}]}
+                    k: {"filters": ["DictionaryFilter", {"_type": "ZstdFilter", "level": 19}]}
                     for k in _RepetativeStringLabelObs
                 },
             },
-            "offsets_filters": ["DoubleDeltaFilter", {"_type": "ZstdFilter", "level": 5}],
+            "offsets_filters": ["DoubleDeltaFilter", {"_type": "ZstdFilter", "level": 19}],
         }
     }
 }
@@ -112,8 +112,8 @@ CENSUS_VAR_PLATFORM_CONFIG = {
     "tiledb": {
         "create": {
             "capacity": 2**16,
-            "dims": {"soma_joinid": {"filters": ["DoubleDeltaFilter", {"_type": "ZstdFilter", "level": 5}]}},
-            "offsets_filters": ["DoubleDeltaFilter", {"_type": "ZstdFilter", "level": 5}],
+            "dims": {"soma_joinid": {"filters": ["DoubleDeltaFilter", {"_type": "ZstdFilter", "level": 19}]}},
+            "offsets_filters": ["DoubleDeltaFilter", {"_type": "ZstdFilter", "level": 19}],
         }
     }
 }
@@ -128,12 +128,15 @@ CENSUS_X_LAYERS_PLATFORM_CONFIG = {
                 "capacity": 2**16,
                 "dims": {
                     "soma_dim_0": {"tile": 2048, "filters": [{"_type": "ZstdFilter", "level": 5}]},
-                    "soma_dim_1": {"tile": 2048, "filters": ["ByteShuffleFilter", {"_type": "ZstdFilter", "level": 5}]},
+                    "soma_dim_1": {
+                        "tile": 2048,
+                        "filters": ["ByteShuffleFilter", {"_type": "ZstdFilter", "level": 5}],
+                    },
                 },
                 "attrs": {"soma_data": {"filters": ["ByteShuffleFilter", {"_type": "ZstdFilter", "level": 5}]}},
                 "cell_order": "row-major",
                 "tile_order": "row-major",
-            }
+            },
         }
     }
 }

--- a/cell_census_builder/manifest.py
+++ b/cell_census_builder/manifest.py
@@ -12,7 +12,7 @@ from .util import fetch_json
 CXG_BASE_URI = "https://api.cellxgene.cziscience.com/"
 
 
-def parse_manifest_file(manifest_fp: io.TextIOBase) -> list[Dataset]:
+def parse_manifest_file(manifest_fp: io.TextIOBase) -> List[Dataset]:
     """
     return manifest as list of tuples, (dataset_id, URI/path), read from the text stream
     """
@@ -30,7 +30,7 @@ def dedup_datasets(datasets: List[Dataset]) -> List[Dataset]:
     return datasets
 
 
-def load_manifest_from_fp(manifest_fp: io.TextIOBase) -> list[Dataset]:
+def load_manifest_from_fp(manifest_fp: io.TextIOBase) -> List[Dataset]:
     logging.info("Loading manifest from file")
     all_datasets = parse_manifest_file(manifest_fp)
     datasets = [
@@ -49,7 +49,7 @@ def null_to_empty_str(val: Union[None, str]) -> str:
     return val
 
 
-def load_manifest_from_CxG() -> list[Dataset]:
+def load_manifest_from_CxG() -> List[Dataset]:
     logging.info("Loading manifest from CELLxGENE data portal...")
 
     # Load all collections and extract dataset_id
@@ -132,7 +132,7 @@ def load_manifest_from_CxG() -> list[Dataset]:
     return [Dataset(**d) for d in datasets.values()]
 
 
-def load_manifest(manifest_fp: Optional[io.TextIOBase] = None) -> list[Dataset]:
+def load_manifest(manifest_fp: Optional[io.TextIOBase] = None) -> List[Dataset]:
     """
     Load dataset manifest from the file pointer if provided, else bootstrap
     the load rom the CELLxGENE REST API.

--- a/cell_census_builder/validate.py
+++ b/cell_census_builder/validate.py
@@ -308,7 +308,7 @@ def validate_X_layers(
                 X = se.ms["RNA"].X[lyr]
                 assert X.schema.field("soma_dim_0").type == pa.int64()
                 assert X.schema.field("soma_dim_1").type == pa.int64()
-                assert X.schema.field("soma_data").type == pa.float32()
+                assert X.schema.field("soma_data").type == CENSUS_X_LAYERS[lyr]
                 assert X.shape == (n_obs, n_vars)
 
     if args.multi_process:

--- a/cell_census_builder/validate.py
+++ b/cell_census_builder/validate.py
@@ -26,9 +26,9 @@ from .globals import (
     CENSUS_SUMMARY_CELL_COUNTS_NAME,
     CENSUS_SUMMARY_NAME,
     CENSUS_VAR_TERM_COLUMNS,
+    CENSUS_X_LAYERS,
     CXG_OBS_TERM_COLUMNS,
     CXG_SCHEMA_VERSION,
-    X_LAYERS,
     TileDB_Ctx,
 )
 from .mp import create_process_pool_executor
@@ -108,7 +108,7 @@ def validate_all_soma_objects_exist(soma_path: str, experiment_builders: List[Ex
         rna = e.ms["RNA"]
         assert "var" in rna and rna["var"].exists() and rna["var"].soma_type == "SOMADataFrame"
         assert "X" in rna and rna["X"].exists() and rna["X"].soma_type == "SOMACollection"
-        for lyr in X_LAYERS:
+        for lyr in CENSUS_X_LAYERS:
             # layers only exist if there are cells in the measurement
             if lyr in rna.X:
                 assert rna.X[lyr].exists() and rna.X[lyr].soma_type == "SOMASparseNdArray"
@@ -298,7 +298,7 @@ def validate_X_layers(
         n_vars = len(census_var_df)
 
         if n_obs > 0:
-            for lyr in X_LAYERS:
+            for lyr in CENSUS_X_LAYERS:
                 assert se.ms["RNA"].X[lyr].exists()
                 X = se.ms["RNA"].X[lyr]
                 assert X.schema.field("soma_dim_0").type == pa.int64()


### PR DESCRIPTION
Changes:
* added hooks for using platform_config to tune Census schema (i.e., do not use default SOMA schema)
* first round of schema tuning - primarily filter pipeline configuration

Unrelated, small changes:
* broaden Python versions supported (changes to type static typing and type checks in the GH action)
* parallelize consolidation pass to reduce build time
* disallow python 3.11 support until numba is updated
