### PR TITLE
accommodate SOMA API name changes

### DIFF
--- a/api/python/cell_census/src/cell_census/experiment_query/query.py
+++ b/api/python/cell_census/src/cell_census/experiment_query/query.py
@@ -50,7 +50,7 @@ class ExperimentQuery:
     IMPORTANT: this class is not thread safe.
 
     IMPORTANT: this query class assumes it can store the full result of both axis dataframe
-    queries in memory, and only provides incremental access to the underlying X NdArray. API
+    queries in memory, and only provides incremental access to the underlying X NDArray. API
     features such as `n_obs` and `n_vars` codify this in the API.
 
     IMPORTANT: you must call `close()` on any instance of this class in order to release
@@ -158,7 +158,7 @@ class ExperimentQuery:
     def n_vars(self) -> int:
         return len(self.var_joinids())
 
-    def _fetchX(self, X: soma.SparseNdArray, prefetch: bool = False) -> Iterator[pa.Table]:
+    def _fetchX(self, X: soma.SparseNDArray, prefetch: bool = False) -> Iterator[pa.Table]:
         assert self._joinids["obs"] is not None
         assert self._joinids["var"] is not None
 
@@ -195,7 +195,7 @@ class ExperimentQuery:
             raise ValueError("Unknown X layer")
 
         X = self.experiment.ms[self.ms].X[layer]
-        if X.soma_type != "SOMASparseNdArray":
+        if X.soma_type != "SOMASparseNDArray":
             raise NotImplementedError("Dense array unsupported")
 
         futures = []
@@ -230,7 +230,7 @@ class ExperimentQuery:
             if _xname not in X_collection:
                 raise ValueError("Unknown X layer name")
             # TODO: dense array slicing
-            if X_collection[_xname].soma_type != "SOMASparseNdArray":
+            if X_collection[_xname].soma_type != "SOMASparseNDArray":
                 raise NotImplementedError("Dense array unsupported")
 
         if column_names is None:

--- a/cell_census_builder/consolidate.py
+++ b/cell_census_builder/consolidate.py
@@ -35,7 +35,7 @@ def consolidate_collection(
     futures = []
     for soma_obj in collection.values():
         type = soma_obj.soma_type
-        if type in ["SOMADataFrame", "SOMASparseNdArray", "SOMADenseNdArray"]:
+        if type in ["SOMADataFrame", "SOMASparseNDArray", "SOMADenseNDArray"]:
             logging.info(f"Consolidate: queuing {type} {soma_obj.uri}")
             futures.append(ppe.submit(consolidate_tiledb_object, soma_obj.uri))
         elif type in ["SOMACollection", "SOMAExperiment", "SOMAMeasurement"]:

--- a/cell_census_builder/experiment_builder.py
+++ b/cell_census_builder/experiment_builder.py
@@ -287,14 +287,14 @@ class ExperimentBuilder:
             assert self.n_var > 0
             measurement = se.ms["RNA"]
             for layer_name in CENSUS_X_LAYERS:
-                snda = soma.SparseNdArray(uricat(measurement.X.uri, layer_name), ctx=TileDB_Ctx()).create(
+                snda = soma.SparseNDArray(uricat(measurement.X.uri, layer_name), ctx=TileDB_Ctx()).create(
                     CENSUS_X_LAYERS[layer_name],
                     (self.n_obs, self.n_var),
                     platform_config=CENSUS_X_LAYERS_PLATFORM_CONFIG[layer_name],
                 )
                 measurement.X.set(layer_name, snda, relative=True)
 
-            presence_matrix = soma.SparseNdArray(
+            presence_matrix = soma.SparseNDArray(
                 uricat(measurement.varp.uri, "dataset_presence_matrix"), ctx=TileDB_Ctx()
             )
             max_dataset_joinid = max(d.soma_joinid for d in datasets)

--- a/cell_census_builder/validate.py
+++ b/cell_census_builder/validate.py
@@ -111,14 +111,14 @@ def validate_all_soma_objects_exist(soma_path: str, experiment_builders: List[Ex
         for lyr in CENSUS_X_LAYERS:
             # layers only exist if there are cells in the measurement
             if lyr in rna.X:
-                assert rna.X[lyr].exists() and rna.X[lyr].soma_type == "SOMASparseNdArray"
+                assert rna.X[lyr].exists() and rna.X[lyr].soma_type == "SOMASparseNDArray"
 
         # and a presence matrix
         assert "varp" in rna and rna["varp"].exists() and rna["varp"].soma_type == "SOMACollection"
         # dataset presence only exists if there are cells in the measurement
         if "dataset_presence_matrix" in rna.varp:
             assert rna.varp["dataset_presence_matrix"].exists()
-            assert rna.varp["dataset_presence_matrix"].soma_type == "SOMASparseNdArray"
+            assert rna.varp["dataset_presence_matrix"].soma_type == "SOMASparseNDArray"
 
     return True
 
@@ -252,7 +252,7 @@ def _validate_X_layers_contents(args: Tuple[str, str, Dataset, List[ExperimentBu
         if len(soma_joinids) > 0:
             assert "raw" in se.ms["RNA"].X and se.ms["RNA"].X["raw"].exists()
 
-            def count_elements(arr: soma.SparseNdArray, join_ids: npt.NDArray[np.int64]) -> int:
+            def count_elements(arr: soma.SparseNDArray, join_ids: npt.NDArray[np.int64]) -> int:
                 # TODO XXX: Work-around for regression TileDB-SOMA#473
                 # return sum(t.non_zero_length for t in arr.read_sparse_tensor((join_ids, slice(None))))
                 return sum(t.non_zero_length for t in arr.read_sparse_tensor((pa.array(join_ids), slice(None))))

--- a/docs/cell_census_schema_0.0.1.md
+++ b/docs/cell_census_schema_0.0.1.md
@@ -665,9 +665,9 @@ For each organism the `SOMAExperiment` MUST contain the following:
 * Cell metadata – `census_obj[“census_data”][organism].obs` – `SOMADataFrame`
 * Data  –  `census_obj[“census_data”][organism].ms` – `SOMACollection`. This `SOMACollection` MUST only contain one `SOMAMeasurement` in `census_obj[“census_data”][organism].ms[“RNA”]` with the following:
 	* Matrix  data –  `census_obj[“census_data”][organism].ms[“RNA”].X` – `SOMACollection`. It MUST contain exactly one layer: 
-		* Count matrix – `census_obj[“census_data”][organism].ms[“RNA”].X[“raw”]` – `SOMASparseNdArray`
+		* Count matrix – `census_obj[“census_data”][organism].ms[“RNA”].X[“raw”]` – `SOMASparseNDArray`
 	* Feature metadata – `census_obj[“census_data”][organism].ms[“RNA”].var` – `SOMAIndexedDataFrame`
-	* Feature dataset presence matrix – `census_obj[“census_data”][organism].ms[“RNA”].varp[“dataset_presence_matrix”]` – `SOMASparseNdArray`
+	* Feature dataset presence matrix – `census_obj[“census_data”][organism].ms[“RNA”].varp[“dataset_presence_matrix”]` – `SOMASparseNDArray`
 
 
 For each organism the `SOMAExperiment` SHOULD NOT contain the following:
@@ -678,9 +678,9 @@ For each organism the `SOMAExperiment` SHOULD NOT contain the following:
 	* `obsp`
 	* `obs_ms`
 
-#### Matrix Data, count (raw) matrix – `census_obj[“census_data”][organism].ms[“RNA”].X[“raw”]` – `SOMASparseNdArray`
+#### Matrix Data, count (raw) matrix – `census_obj[“census_data”][organism].ms[“RNA”].X[“raw”]` – `SOMASparseNDArray`
 
-Per the CELLxGENE dataset schema, [all RNA assays MUST include UMI or read counts](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.0.0/schema.md#x-matrix-layers). These counts MUST be encoded as `float32` in this `SOMASparseNdArray` with a fill value of zero (0), and no explicitly stored zero values.
+Per the CELLxGENE dataset schema, [all RNA assays MUST include UMI or read counts](https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/3.0.0/schema.md#x-matrix-layers). These counts MUST be encoded as `float32` in this `SOMASparseNDArray` with a fill value of zero (0), and no explicitly stored zero values.
 
 
 #### Feature metadata – `census_obj[“census_data”][organism].ms[“RNA”].var` – `SOMADataFrame`
@@ -718,9 +718,9 @@ The following columns MUST be included:
 </tbody>
 </table>
 
-#### Feature dataset presence matrix – `census_obj[“census_data”][organism].ms[“RNA”].varp[“dataset_presence”]` – `SOMASparseNdArray`
+#### Feature dataset presence matrix – `census_obj[“census_data”][organism].ms[“RNA”].varp[“dataset_presence”]` – `SOMASparseNDArray`
 
-In some datasets, there are features not included in the source data. To clarify the difference between features that were not included and features that were not measured, the Cell Census MUST include a presence matrix encoded as a `SOMASparseNdArray`.
+In some datasets, there are features not included in the source data. To clarify the difference between features that were not included and features that were not measured, the Cell Census MUST include a presence matrix encoded as a `SOMASparseNDArray`.
 
 For all features included in the Cell Census, the dataset presence matrix MUST indicate what features are included in each dataset of the Cell Census. This information MUST be encoded as a boolean matrix, `True` indicates the feature was included in the dataset, `False` otherwise. This is a two-dimensional matrix and it MUST be `N x M` where `N` is the number of datasets and `M` is the number of features. The matrix is indexed by the `soma_joinid` value of  `census_obj[“census_info”][“datasets”]` and `census_obj[“census_data”][organism].ms[“RNA”].var`.
 


### PR DESCRIPTION
SOMA API name change  `s/NdArray/NDArray/g`  - rippled through the cell_census package.

See single-cell-data/TileDB-SOMA#608
