### PR TITLE
Refine unit test workflows

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,10 +1,9 @@
 name: cell_census Python package unit tests
 
 on:
-  # pull_request:
-  # push:
-  #   branches: [main]
-  workflow_dispatch
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   unit_tests:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,14 +9,10 @@ jobs:
   unit_tests:
     runs-on: ubuntu-latest
 
-    # defaults:
-    #   run:
-    #     working-directory: api/python/cell_census/
-
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,9 +9,9 @@ jobs:
   unit_tests:
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        working-directory: api/python/cell_census/
+    # defaults:
+    #   run:
+    #     working-directory: api/python/cell_census/
 
     strategy:
       matrix:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -31,4 +31,4 @@ jobs:
           pip install -e ./api/python/cell_census/
       - name: Test with pytest
         run: |
-          pytest ./tests/
+          pytest ./api/python/cell_census/tests/

--- a/api/python/cell_census/README.md
+++ b/api/python/cell_census/README.md
@@ -1,8 +1,12 @@
+# CELLxGENE Cell Census
+
 The `cell_census` package provides an API to facilitate use of the CZI Science Cell Census.
 
 **Status**: Unstable, under rapid development
 
-For more information, see the [cell_census repo](https://github.com/chanzuckerberg/cell-census/)### For More Help
+For more information, see the [cell_census repo](https://github.com/chanzuckerberg/cell-census/)
+
+### For More Help
 
 For more help, please file a issue on the repo, or contact us at <cellxgene@chanzuckerberg.com>
 

--- a/api/python/cell_census/scripts/requirements-dev.txt
+++ b/api/python/cell_census/scripts/requirements-dev.txt
@@ -7,3 +7,4 @@ types-setuptools
 types-requests
 numpy
 pytest
+twine

--- a/api/python/cell_census/setup.cfg
+++ b/api/python/cell_census/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     numpy
     requests
     tiledb>=0.19.0
-    tiledbsoma==0.2.0rc0
+    tiledbsoma==0.5.0a2
     typing_extensions
     s3fs
     scikit-misc

--- a/api/python/cell_census/setup.cfg
+++ b/api/python/cell_census/setup.cfg
@@ -27,8 +27,8 @@ install_requires =
     numba
     numpy
     requests
-    tiledb>=0.18.1
-    tiledbsoma>=0.5.*
+    tiledb>=0.19.0
+    tiledbsoma==0.2.0rc0
     typing_extensions
     s3fs
     scikit-misc

--- a/api/python/cell_census/setup.cfg
+++ b/api/python/cell_census/setup.cfg
@@ -16,13 +16,12 @@ classifiers =
     Topic :: Scientific/Engineering :: Bio-Informatics
     Operating System :: POSIX :: Linux
     Operating System :: MacOS :: MacOS X
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
 
 [options]
-python_requires = >= 3.7, < 3.11
+python_requires = >= 3.8, < 3.11
 install_requires =
     numba
     numpy

--- a/api/python/cell_census/setup.cfg
+++ b/api/python/cell_census/setup.cfg
@@ -5,6 +5,7 @@ author = Chan Zuckerberg Initiative
 author_email = cellxgene@chanzuckerberg.com
 description = API to simplify use of the CZI Science CELLxGENE Cell Census
 long_description = file: README.md, LICENSE
+long_description_content_type = text/markdown
 license = MIT
 url = https://github.com/chanzuckerberg/cell-census
 classifiers =

--- a/api/python/cell_census/src/cell_census/__init__.py
+++ b/api/python/cell_census/src/cell_census/__init__.py
@@ -4,7 +4,7 @@ from .open import download_source_h5ad, get_source_h5ad_uri, open_soma
 from .presence_matrix import get_presence_matrix
 from .release_directory import get_census_version_description, get_census_version_directory
 
-__version__ = "0.0.1-dev0"
+__version__ = "0.0.1-rc0"
 
 __all__ = [
     "download_source_h5ad",


### PR DESCRIPTION
Changes:
* Pin the cell_census package dependency for tiledbsoma to 0.5.0a2
* Set the supported python versions (in setup.cfg) to Python 3.8-3.10.  3.11 not supported yet due to numba, and python 3.7 not supported due to tiledbsoma.
* Fix & enable the  unit test workflow for Python matrix [Linux, MacOS] X [Py3.8, Py3.9, Py3.10]
* change package version to 0.0.1-rc0
