### PR TITLE
docs: update link to Discover API schema docs

### DIFF
--- a/docs/cell_census_schema_0.0.1.md
+++ b/docs/cell_census_schema_0.0.1.md
@@ -349,7 +349,7 @@ All datasets used to build the Cell Census MUST be included in a table modeled a
   <tr>
     <td>collection_id</td>
     <td>string</td>
-    <td rowspan="5">As Defined in CELLxGENE Discover <a href="https://github.com/chanzuckerberg/single-cell/blob/main/design-documents/0001-data-portal-architecture/text.md#data-model">data schema</a>.</td>
+    <td rowspan="5">As defined in CELLxGENE Discover <a href="https://api.cellxgene.cziscience.com/curation/ui/">data schema</a> (see &quot;Schemas&quot; section for field definitions)".</td>
   </tr>
   <tr>
     <td>collection_name</td>


### PR DESCRIPTION
Changed link for census metadata fields that are from the Data Portal by linking out to the [Discover API schema docs](https://api.cellxgene.cziscience.com/curation/ui/). This API's schema docs will have a data model diagram for an overview, once we deploy https://github.com/chanzuckerberg/single-cell-data-portal/pull/3844 to prod. The API schema docs already have specific definitions for most of the fields being referenced (in the "Schemas" section), which should be sufficient. We can enhance the field descriptions as needed.