### PR TITLE
presence matrix location change in schema 0.2.0

### DIFF
--- a/api/python/cell_census/src/cell_census/presence_matrix.py
+++ b/api/python/cell_census/src/cell_census/presence_matrix.py
@@ -36,5 +36,5 @@ def get_presence_matrix(
     """
 
     exp = get_experiment(census, organism)
-    presence = exp.ms[measurement_name].varp["dataset_presence_matrix"]
+    presence = exp.ms[measurement_name]["feature_dataset_presence_matrix"]
     return presence.read((slice(None),)).csrs().concat().to_scipy()

--- a/api/python/notebooks/analysis_demo/comp_bio_explore_and_load_lung_data.ipynb
+++ b/api/python/notebooks/analysis_demo/comp_bio_explore_and_load_lung_data.ipynb
@@ -1452,7 +1452,7 @@
     "\n",
     "So let's take a look at the number of genes that were measured in each of those datasets.\n",
     "\n",
-    "To accomplish this we can use the \"dataset presence matrix\" at `census[\"census_data\"][\"homo_sapiens\"].ms[\"RNA\"].varp[\"dataset_presence_matrix\"]`. This is a boolean matrix `N x M` where `N` is the number of datasets and `M` is the number of genes in the Cell Census.\n",
+    "To accomplish this we can use the \"dataset presence matrix\" at `census[\"census_data\"][\"homo_sapiens\"].ms[\"RNA\"][\"feature_dataset_presence_matrix\"]`. This is a boolean matrix `N x M` where `N` is the number of datasets and `M` is the number of genes in the Cell Census.\n",
     "\n",
     "So we can select the rows corresponding to the lung datasets and perform a row-wise sum.\n"
    ]
@@ -2435,7 +2435,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.16 (main, Dec  7 2022, 01:11:51) \n[GCC 9.4.0]"
   },
   "vscode": {
    "interpreter": {

--- a/api/python/notebooks/analysis_demo/comp_bio_normalizing_full_gene_sequencing.ipynb
+++ b/api/python/notebooks/analysis_demo/comp_bio_normalizing_full_gene_sequencing.ipynb
@@ -198,6 +198,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -205,7 +206,7 @@
     "\n",
     "By default `cell_census.get_anndata()` fetches all genes in the Cell Census. So let's first identify the genes that were measured in this dataset and subset the `AnnData` to only include those. \n",
     "\n",
-    "To this goal we can use the \"Dataset Presence Matrix\" in `census[\"census_data\"][\"mus_musculus\"].ms[\"RNA\"].varp[\"dataset_presence_matrix\"]`. This is a boolean matrix `N x M` where `N` is the number of datasets and `M` is the number of genes in the Cell Census, `True` indicates that a gene was measured in a dataset."
+    "To this goal we can use the \"Dataset Presence Matrix\" in `census[\"census_data\"][\"mus_musculus\"].ms[\"RNA\"][\"feature_dataset_presence_matrix\"]`. This is a boolean matrix `N x M` where `N` is the number of datasets and `M` is the number of genes in the Cell Census, `True` indicates that a gene was measured in a dataset."
    ]
   },
   {
@@ -470,7 +471,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.16 (main, Dec  7 2022, 01:11:51) \n[GCC 9.4.0]"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Update the Python API and notebooks to look for the presence matrix in the new location.

Partially addresses #60 

Related to #69 and #66

NOTE: all unit tests against the live corpus will fail until a new data build is available.