### PR TITLE
fix: typos in census_axis_query.ipynb

### DIFF
--- a/api/python/notebooks/api_demo/census_axis_query.ipynb
+++ b/api/python/notebooks/api_demo/census_axis_query.ipynb
@@ -96,9 +96,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Summarize a subset of cell types, selected with a `value_fitler`\n",
+    "### Summarize a subset of cell types, selected with a `value_filter`\n",
     "\n",
-    "This example utilizes a SOMA \"value filter\" to read the subset of cells with `tissue_ontologyy_term_id` equal to `UBERON:0002048` (lung tissue), and summarizes the query result using Pandas."
+    "This example utilizes a SOMA \"value filter\" to read the subset of cells with `tissue_ontology_term_id` equal to `UBERON:0002048` (lung tissue), and summarizes the query result using Pandas."
    ]
   },
   {

--- a/api/python/notebooks/api_demo/census_compute_over_X.ipynb
+++ b/api/python/notebooks/api_demo/census_compute_over_X.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "Many statistics, such as `mean`, are easy to calculate incrementally.  This cell demonstrates a query on the `X['raw']` sparse nD array, which will return results in batches. Accumulate the sum and count incrementally, into `raw_sum` and `raw_n`, and then compute mean.\n",
     "\n",
-    "First define a query - in this case a slice over the obs axis for cells with a specific tissue & sex value, and all genes on the var axis.  The `query.X()` method returns an iterator of results, each as a PyArrow Table.  Each table will contain the sparse X data and obs/var coordinates, using standad SOMA names:\n",
+    "First define a query - in this case a slice over the obs axis for cells with a specific tissue & sex value, and all genes on the var axis.  The `query.X()` method returns an iterator of results, each as a PyArrow Table.  Each table will contain the sparse X data and obs/var coordinates, using standard SOMA names:\n",
     "* `soma_data` - the X value (float32)\n",
     "* `soma_dim_0` - the obs coordinate (int64)\n",
     "* `soma_dim_1` - the var coordinate (int64)\n",


### PR DESCRIPTION
Fix two typos in the `census_axis_query.ipynb` notebook.