### PR TITLE
builder fixes

### DIFF
--- a/tools/cell_census_builder/manifest.py
+++ b/tools/cell_census_builder/manifest.py
@@ -69,6 +69,8 @@ def load_manifest_from_CxG() -> List[Dataset]:
     logging.info(f"Found {len(datasets)} datasets, in {len(collections)} collections")
 
     # load per-dataset schema version
+    # max_workers currently set to 4 (was 8) and 1 sec delay added per API call due to
+    # https://github.com/chanzuckerberg/single-cell-data-portal/issues/3535
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as tp:
         dataset_metadata = tp.map(
             lambda d: fetch_json(

--- a/tools/cell_census_builder/manifest.py
+++ b/tools/cell_census_builder/manifest.py
@@ -70,10 +70,11 @@ def load_manifest_from_CxG() -> List[Dataset]:
     logging.info(f"Found {len(datasets)} datasets, in {len(collections)} collections")
 
     # load per-dataset schema version
-    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as tp:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as tp:
         dataset_metadata = tp.map(
             lambda d: fetch_json(
-                f"{CXG_BASE_URI}curation/v1/collections/{d['collection_id']}/datasets/{d['dataset_id']}"
+                f"{CXG_BASE_URI}curation/v1/collections/{d['collection_id']}/datasets/{d['dataset_id']}",
+                delay_secs=1
             ),
             datasets.values(),
         )

--- a/tools/cell_census_builder/manifest.py
+++ b/tools/cell_census_builder/manifest.py
@@ -65,7 +65,7 @@ def load_manifest_from_CxG() -> List[Dataset]:
         }
         for collection in collections
         for dataset in collection["datasets"]
-        if dataset["tombstone"] is False  # ignore anything that has been deleted
+        # if dataset["tombstone"] is False  # ignore anything that has been deleted
     }
     logging.info(f"Found {len(datasets)} datasets, in {len(collections)} collections")
 

--- a/tools/cell_census_builder/manifest.py
+++ b/tools/cell_census_builder/manifest.py
@@ -65,7 +65,6 @@ def load_manifest_from_CxG() -> List[Dataset]:
         }
         for collection in collections
         for dataset in collection["datasets"]
-        # if dataset["tombstone"] is False  # ignore anything that has been deleted
     }
     logging.info(f"Found {len(datasets)} datasets, in {len(collections)} collections")
 

--- a/tools/cell_census_builder/scripts/aws/mount_instance_storage.sh
+++ b/tools/cell_census_builder/scripts/aws/mount_instance_storage.sh
@@ -9,6 +9,8 @@
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/raid-config.html
 #
 
+DEVICES="$@"
+
 # exit immediately when a command fails
 set -e
 # treat unset variables as an error and exit immediately
@@ -75,6 +77,6 @@ function mount_volume {
   chmod 777 ${MOUNTPOINT}
 }
 
-create_volume $(detect_devices ${DEVICE_PREFIX})
+create_volume ${DEVICES:-$(detect_devices ${DEVICE_PREFIX})}
 mount_volume
 echo "Done. Mounted on ${MOUNTPOINT}."

--- a/tools/cell_census_builder/scripts/aws/mount_instance_storage.sh
+++ b/tools/cell_census_builder/scripts/aws/mount_instance_storage.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
-# This automates mounting all instance (ephemeral) storage onto a file
-# system.  If a single device is found, it creates an ext4 file system.
-# If multiple are found, it creates a RAID0 group, and an ext4 file
-# system on top of it.
+# This automates mounting either all of the instance (ephemeral) storage 
+# devices or the specified devices onto a file system.  If a single device
+# is found, it creates an ext4 file system. If multiple devices are found or specified, 
+# it creates a RAID0 group, and an ext4 file system on top of it.
+# 
+# Usage:
+# mount_instance_storage.sh [DEVICE]...
+# Example:
+# mount_instance_storage.sh /dev/nvme{4,5}n1
 #
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/add-instance-store-volumes.html
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/raid-config.html

--- a/tools/cell_census_builder/scripts/aws/swapon_instance_storage.sh
+++ b/tools/cell_census_builder/scripts/aws/swapon_instance_storage.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
-# This automates adding all instance (ephemeral) storage as swap
+# This automates adding either all or the specified number of instance 
+# (ephemeral) storage devices as swap
 #
+# Usage:
+# swapon_instance_storage.sh [DEVICE_COUNT]
+# Example:
+# swapon_instance_storage.sh 3
+##
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-store-swap-volumes.html
 
 NUM_DEVICES=$1

--- a/tools/cell_census_builder/scripts/aws/swapon_instance_storage.sh
+++ b/tools/cell_census_builder/scripts/aws/swapon_instance_storage.sh
@@ -4,6 +4,8 @@
 #
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-store-swap-volumes.html
 
+NUM_DEVICES=$1
+
 # exit immediately when a command fails
 set -e
 # treat unset variables as an error and exit immediately
@@ -37,7 +39,9 @@ for d in bdevs:
   lsblk --json --output NAME,TYPE,MOUNTPOINT | python3 -c "${PY_CMD}" "$1"
 }
 
-for bdev in $(detect_devices ${DEVICE_PREFIX}); do
+DEVICES=( `detect_devices ${DEVICE_PREFIX}` )
+# For NUM_DEVICES devices (or all devices if NUM_DEVICES not specified), add to swap
+for bdev in ${DEVICES[*]:0:${NUM_DEVICES:-${#DEVICES[*]}}}; do
   echo "Adding ${bdev}"
   mkswap ${bdev}
   swapon -v ${bdev}

--- a/tools/cell_census_builder/util.py
+++ b/tools/cell_census_builder/util.py
@@ -6,6 +6,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import requests
+import time
 from scipy import sparse
 
 
@@ -62,9 +63,10 @@ def uricat(container_uri: str, *paths: str) -> str:
     return uri
 
 
-def fetch_json(url: str) -> object:
+def fetch_json(url: str, delay_secs: float=0.0) -> object:
     response = requests.get(url)
     response.raise_for_status()
+    time.sleep(delay_secs)
     return response.json()
 
 


### PR DESCRIPTION
* slow down API requests to avoid DOS'ing Discover API (temporary fix)
* remove reading of tombstone attribute in API response (no longer exists)
* aws scripts allow parameterization of which disk devices to use: `swap_instance_storage.sh` takes a count, while `mount_instance_storage.sh` takes list of actual devices (can be improved)