### PR TITLE
tiledb version dependency fixes

### DIFF
--- a/api/python/cell_census/pyproject.toml
+++ b/api/python/cell_census/pyproject.toml
@@ -30,8 +30,11 @@ dependencies= [
     "numba>=0.55",
     "numpy>=1.21",
     "requests",
-    "tiledb>=0.19.0",
+    # NOTE: The API's version of tiledbsoma MUST be >= the builder's tiledbsoma version, to ensure reader compatibility
+    # of TileDB on-disk storage format. Make sure this doesn't fall behind the builder's tiledbsoma version.
     "tiledbsoma==0.5.0a6",
+    # NOTE: tiledb is also a requirement of the API, but tiledbsoma also has a tiledb dependency, so just use the same version here
+    # "tiledb",
     "typing_extensions",
     "s3fs",
     "scikit-misc",

--- a/tools/scripts/requirements.txt
+++ b/tools/scripts/requirements.txt
@@ -2,9 +2,13 @@ pyarrow
 pandas
 anndata
 numpy
-tiledb
 # NOTE: You can also build this dependency from source, per ./notebooks/README.md.
+# NOTE: The builder's version of tiledbsoma MUST be <= the API's tiledbsoma version, to ensure reader compatibility
+# of TileDB on-disk storage format
 tiledbsoma==0.5.0a6
+# NOTE: tiledb is also a requirement of the builder, but builder must not use a tiledb version that is ahead of
+# tiledbsoma's tiledb version (so just use the same version)
+# tiledb
 scipy
 fsspec
 s3fs


### PR DESCRIPTION
This partially addresses a bug whereby builder ("writer") can potentially create a census with a TileDB on-disk format that is incompatible with the TileDB version used by the API ("reader"), due to it being ahead of the reader's version. The change here only ensures that Cell Census components are using the same version of TileDB used by TileDB-SOMA. An additional fix is needed in TileDB-SOMA to ensure that the TileDB version it uses to write data is always <= the TileDB version it usese to read data.

Changes:
- Use the same tiledb version as tiledbsoma to ensure read/write compatibility with on-disk TileDB formats
- Add notes about tiledbsoma version constraints between Builder and API