### PR TITLE
census builder performance fixes

### DIFF
--- a/tools/cell_census_builder/__main__.py
+++ b/tools/cell_census_builder/__main__.py
@@ -81,8 +81,7 @@ def main() -> int:
         assert cc != 0 or all(e.is_finished() for e in experiment_builders)
 
     if cc == 0 and (args.subcommand == "validate" or args.validate):
-        # validate() returns True on success, raises on failure
-        cc = 0 if validate(args, experiment_builders) else 1
+        validate(args, experiment_builders)
 
     return cc
 

--- a/tools/cell_census_builder/__main__.py
+++ b/tools/cell_census_builder/__main__.py
@@ -81,7 +81,8 @@ def main() -> int:
         assert cc != 0 or all(e.is_finished() for e in experiment_builders)
 
     if cc == 0 and (args.subcommand == "validate" or args.validate):
-        cc = validate(args, experiment_builders)
+        # validate() returns True on success, raises on failure
+        cc = 0 if validate(args, experiment_builders) else 1
 
     return cc
 

--- a/tools/cell_census_builder/consolidate.py
+++ b/tools/cell_census_builder/consolidate.py
@@ -48,6 +48,6 @@ def consolidate_collection(
 
 def consolidate_tiledb_object(uri: str) -> str:
     logging.info(f"Consolidate: starting {uri}")
-    tiledb.consolidate(uri, config=tiledb.Config({"sm.consolidation.buffer_size": 16 * 1024**3}))
+    tiledb.consolidate(uri, config=tiledb.Config({"sm.consolidation.buffer_size": 1 * 1024**3}))
     tiledb.vacuum(uri)
     return uri

--- a/tools/cell_census_builder/mp.py
+++ b/tools/cell_census_builder/mp.py
@@ -35,6 +35,7 @@ def process_initializer(verbose: int = 0) -> None:
                 {
                     "py.init_buffer_bytes": 512 * 1024**2,
                     "py.deduplicate": "true",
+                    "soma.init_buffer_bytes": 512 * 1024**2,
                 }
             )
         )


### PR DESCRIPTION
Changes:
* reduce the consolidation buffer per TileDB guidance.  Has effect of removing the excessive memory contention which was causing very long build times.  With this change, we are back to a 6-7 hour build (tested on a c6id.32xlarge with filesystem on EBS).
* added soma buffer config which was missing
* fixed a process return value bug which caused successful runs to return a process code of 1 rather than the intended 0

Fixes #86 