### PR TITLE
Add git SHA to the metadata field of census

### DIFF
--- a/tools/cell_census_builder/__main__.py
+++ b/tools/cell_census_builder/__main__.py
@@ -139,7 +139,7 @@ def build(
     if args.consolidate:
         consolidate(args, top_level_collection.uri)
 
-    add_git_commit_sha(top_level_collection[CENSUS_INFO_NAME])
+    add_git_commit_sha(top_level_collection)
 
     return 0
 
@@ -264,10 +264,9 @@ def build_step3_create_X_layers(
 
     logging.info("Build step 3 - X layer creation - finished")
 
-def add_git_commit_sha(info_collection: soma.Collection) -> None:
+def add_git_commit_sha(top_level_collection: soma.Collection) -> None:
     sha = get_git_commit_sha()
-    info_collection.set(CENSUS_BUILDER_GIT_SHA, sha, relative=True)
-
+    top_level_collection.metadata["git_commit_sha"] = sha
 
 def create_args_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="cell_census_builder")

--- a/tools/cell_census_builder/__main__.py
+++ b/tools/cell_census_builder/__main__.py
@@ -161,6 +161,9 @@ def create_top_level_collections(soma_path: str) -> soma.Collection:
     top_level_collection.metadata["cxg_schema_version"] = CXG_SCHEMA_VERSION
     top_level_collection.metadata["census_schema_version"] = CENSUS_SCHEMA_VERSION
 
+    sha = get_git_commit_sha()
+    top_level_collection.metadata["git_commit_sha"] = sha
+
     # Create sub-collections for experiments, etc.
     for n in [CENSUS_INFO_NAME, CENSUS_DATA_NAME]:
         cltn = soma.Collection(uricat(top_level_collection.uri, n),
@@ -263,10 +266,6 @@ def build_step3_create_X_layers(
         e.commit_presence_matrix(filtered_datasets)
 
     logging.info("Build step 3 - X layer creation - finished")
-
-def add_git_commit_sha(top_level_collection: soma.Collection) -> None:
-    sha = get_git_commit_sha()
-    top_level_collection.metadata["git_commit_sha"] = sha
 
 def create_args_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="cell_census_builder")

--- a/tools/cell_census_builder/__main__.py
+++ b/tools/cell_census_builder/__main__.py
@@ -14,7 +14,7 @@ from .census_summary import create_census_summary
 from .consolidate import consolidate
 from .datasets import Dataset, assign_soma_joinids, create_dataset_manifest
 from .experiment_builder import ExperimentBuilder, populate_X_layers
-from .globals import CENSUS_BUILDER_GIT_SHA, CENSUS_SCHEMA_VERSION, CXG_SCHEMA_VERSION, RNA_SEQ, CENSUS_DATA_NAME, CENSUS_INFO_NAME, \
+from .globals import CENSUS_SCHEMA_VERSION, CXG_SCHEMA_VERSION, RNA_SEQ, CENSUS_DATA_NAME, CENSUS_INFO_NAME, \
     SOMA_TileDB_Context
 from .manifest import load_manifest
 from .mp import process_initializer

--- a/tools/cell_census_builder/__main__.py
+++ b/tools/cell_census_builder/__main__.py
@@ -144,8 +144,6 @@ def build(
     if args.consolidate:
         consolidate(args, top_level_collection.uri)
 
-    add_git_commit_sha(top_level_collection)
-
     return 0
 
 

--- a/tools/cell_census_builder/__main__.py
+++ b/tools/cell_census_builder/__main__.py
@@ -20,7 +20,7 @@ from .manifest import load_manifest
 from .mp import process_initializer
 from .source_assets import stage_source_assets
 from .summary_cell_counts import create_census_summary_cell_counts
-from .util import get_git_commit_sha, uricat
+from .util import get_git_commit_sha, uricat, is_git_repo_dirty
 from .validate import validate
 
 
@@ -108,6 +108,11 @@ def build(
     # Don't clobber an existing census build
     if os.path.exists(soma_path) or os.path.exists(assets_path):
         logging.error("Census build path already exists - aborting build")
+        return 1
+
+    # Ensure that the git tree is clean
+    if is_git_repo_dirty():
+        logging.error("The git repo has uncommitted changes - aborting build")
         return 1
 
     # Create top-level build directories

--- a/tools/cell_census_builder/__main__.py
+++ b/tools/cell_census_builder/__main__.py
@@ -14,13 +14,13 @@ from .census_summary import create_census_summary
 from .consolidate import consolidate
 from .datasets import Dataset, assign_soma_joinids, create_dataset_manifest
 from .experiment_builder import ExperimentBuilder, populate_X_layers
-from .globals import CENSUS_SCHEMA_VERSION, CXG_SCHEMA_VERSION, RNA_SEQ, CENSUS_DATA_NAME, CENSUS_INFO_NAME, \
+from .globals import CENSUS_BUILDER_GIT_SHA, CENSUS_SCHEMA_VERSION, CXG_SCHEMA_VERSION, RNA_SEQ, CENSUS_DATA_NAME, CENSUS_INFO_NAME, \
     SOMA_TileDB_Context
 from .manifest import load_manifest
 from .mp import process_initializer
 from .source_assets import stage_source_assets
 from .summary_cell_counts import create_census_summary_cell_counts
-from .util import uricat
+from .util import get_git_commit_sha, uricat
 from .validate import validate
 
 
@@ -138,6 +138,8 @@ def build(
 
     if args.consolidate:
         consolidate(args, top_level_collection.uri)
+
+    add_git_commit_sha(top_level_collection[CENSUS_INFO_NAME])
 
     return 0
 
@@ -261,6 +263,10 @@ def build_step3_create_X_layers(
         e.commit_presence_matrix(filtered_datasets)
 
     logging.info("Build step 3 - X layer creation - finished")
+
+def add_git_commit_sha(info_collection: soma.Collection) -> None:
+    sha = get_git_commit_sha()
+    info_collection.set(CENSUS_BUILDER_GIT_SHA, sha, relative=True)
 
 
 def create_args_parser() -> argparse.ArgumentParser:

--- a/tools/cell_census_builder/globals.py
+++ b/tools/cell_census_builder/globals.py
@@ -42,9 +42,6 @@ CENSUS_SUMMARY_CELL_COUNTS_NAME = "summary_cell_counts"  # object name
 # "census_info"/"summary_cell_counts" SOMA Dataframe
 CENSUS_SUMMARY_NAME = "summary"
 
-# "census_info"/"builder_git_sha" string
-CENSUS_BUILDER_GIT_SHA = "builder-git-sha"
-
 # "census_data"/{organism}/ms/"RNA" SOMA Matrix
 MEASUREMENT_RNA_NAME = "RNA"
 

--- a/tools/cell_census_builder/globals.py
+++ b/tools/cell_census_builder/globals.py
@@ -42,6 +42,9 @@ CENSUS_SUMMARY_CELL_COUNTS_NAME = "summary_cell_counts"  # object name
 # "census_info"/"summary_cell_counts" SOMA Dataframe
 CENSUS_SUMMARY_NAME = "summary"
 
+# "census_info"/"builder_git_sha" string
+CENSUS_BUILDER_GIT_SHA = "builder-git-sha"
+
 # "census_data"/{organism}/ms/"RNA" SOMA Matrix
 MEASUREMENT_RNA_NAME = "RNA"
 

--- a/tools/cell_census_builder/util.py
+++ b/tools/cell_census_builder/util.py
@@ -121,3 +121,10 @@ def get_git_commit_sha() -> str:
     """
     repo = git.Repo(search_parent_directories=True)
     return repo.head.object.hexsha
+
+def is_git_repo_dirty() -> bool:
+    """
+    Returns True if the git repo is dirty, i.e. there are uncommitted changes
+    """
+    repo = git.Repo()
+    return repo.is_dirty()

--- a/tools/cell_census_builder/util.py
+++ b/tools/cell_census_builder/util.py
@@ -120,11 +120,13 @@ def get_git_commit_sha() -> str:
     Returns the git commit SHA for the current repo
     """
     repo = git.Repo(search_parent_directories=True)
-    return repo.head.object.hexsha
+    hexsha: str = repo.head.object.hexsha
+    return hexsha
 
 def is_git_repo_dirty() -> bool:
     """
     Returns True if the git repo is dirty, i.e. there are uncommitted changes
     """
     repo = git.Repo()
-    return repo.is_dirty()
+    is_dirty: bool = repo.is_dirty()
+    return is_dirty

--- a/tools/cell_census_builder/util.py
+++ b/tools/cell_census_builder/util.py
@@ -9,6 +9,8 @@ import requests
 import time
 from scipy import sparse
 
+import git
+
 
 def array_chunker(arr: Union[npt.NDArray[Any], sparse.spmatrix]) -> sparse.coo_matrix:
     """
@@ -112,3 +114,10 @@ def anndata_ordered_bool_issue_853_workaround(df: pd.DataFrame) -> pd.DataFrame:
             df[k] = df[k].cat.set_categories(df[k].cat.categories, ordered=bool(df[k].cat.ordered))
 
     return df
+
+def get_git_commit_sha() -> str:
+    """
+    Returns the git commit SHA for the current repo
+    """
+    repo = git.Repo(search_parent_directories=True)
+    return repo.head.object.hexsha

--- a/tools/cell_census_builder/validate.py
+++ b/tools/cell_census_builder/validate.py
@@ -70,6 +70,7 @@ def validate_all_soma_objects_exist(soma_path: str, experiment_builders: List[Ex
         "census_schema_version" in census.metadata and census.metadata["census_schema_version"] == CENSUS_SCHEMA_VERSION
     )
     assert "created_on" in census.metadata and datetime.fromisoformat(census.metadata["created_on"])
+    assert "git_commit_sha" in census.metadata
 
     for name in [CENSUS_INFO_NAME, CENSUS_DATA_NAME]:
         assert name in census

--- a/tools/scripts/requirements.txt
+++ b/tools/scripts/requirements.txt
@@ -17,3 +17,4 @@ aiohttp
 Cython  # required by owlready2
 wheel  # required by owlready2
 owlready2
+gitpython


### PR DESCRIPTION
Adds the git commit SHA field to the `metadata` object of the top level collection.

Tested by running a local build of the census and inspecting the result