### PR TITLE
Add Python 3.7 support

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/api/python/cell_census/README.md
+++ b/api/python/cell_census/README.md
@@ -2,9 +2,9 @@
 
 The `cell_census` package provides an API to facilitate use of the CZI Science Cell Census. The Cell Census is a versioned container for the single-cell data hosted at [CELLxGENE Discover](https://cellxgene.cziscience.com/).
 
-**Status**: Unstable, under rapid development
+**Status**: Pre-release, under rapid development. Expect API changes.
 
-For more information, see the [cell_census repo](https://github.com/chanzuckerberg/cell-census/)
+For more information, see the [cell_census repo](https://github.com/chanzuckerberg/cell-census/).
 
 ### For More Help
 

--- a/api/python/cell_census/pyproject.toml
+++ b/api/python/cell_census/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">= 3.8, < 3.11"
+requires-python = ">= 3.7, < 3.11"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Developers",
@@ -22,6 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/api/python/cell_census/src/cell_census/__init__.py
+++ b/api/python/cell_census/src/cell_census/__init__.py
@@ -1,4 +1,10 @@
-from importlib.metadata import PackageNotFoundError, version
+try:
+    from importlib import metadata  # type: ignore[attr-defined]
+except ImportError:
+    # for python <=3.7
+    import importlib_metadata as metadata  # type: ignore[no-redef]
+
+# from importlib.metadata import PackageNotFoundError, version
 
 from .experiment import get_experiment
 from .get_anndata import get_anndata
@@ -7,8 +13,8 @@ from .presence_matrix import get_presence_matrix
 from .release_directory import get_census_version_description, get_census_version_directory
 
 try:
-    __version__ = version("cell_census")
-except PackageNotFoundError:
+    __version__ = metadata.version("cell_census")
+except metadata.PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0-unknown"
 


### PR DESCRIPTION
With this PR, we now support Python versions 3.7 to 3.10.

Python 3.11 support is pending numba support for the same.

Fixes #120 
