### PR TITLE
Coords param change for get_anndata

### DIFF
--- a/api/python/cell_census/src/cell_census/get_anndata.py
+++ b/api/python/cell_census/src/cell_census/get_anndata.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional
 
 import anndata
 import tiledbsoma as soma
@@ -18,9 +18,9 @@ def get_anndata(
     measurement_name: str = "RNA",
     X_name: str = "raw",
     obs_value_filter: Optional[str] = None,
-    obs_coords: Optional[Tuple[SparseDFCoord, ...]] = None,
+    obs_coords: Optional[SparseDFCoord] = None,
     var_value_filter: Optional[str] = None,
-    var_coords: Optional[Tuple[SparseDFCoord, ...]] = None,
+    var_coords: Optional[SparseDFCoord] = None,
     column_names: Optional[AxisColumnNames] = None,
 ) -> anndata.AnnData:
     """
@@ -44,13 +44,13 @@ def get_anndata(
         SOMA ``value_filter`` syntax.
     obs_coords: tuple[int, slice or NumPy ArrayLike of int], default None
         Coordinates for the ``obs`` axis, which is indexed by the ``soma_joinid`` value.
-        May be a tuple containing an int, a list of int, or a slice.
+        May be an int, a list of int, or a slice. The default, None, selects all.
     var_value_filter: str, default None
         Value filter for the ``var`` metadata. Value is a filter query written in the
         SOMA ``value_filter`` syntax.
     var_coords: tuple[int, slice or NumPy ArrayLike of int], default None
         Coordinates for the ``var`` axis, which is indexed by the ``soma_joinid`` value.
-        May be a tuple containing an int, a list of int, or a slice.
+        May be an int, a list of int, or a slice. The default, None, selects all.
     column_names: dict[Literal['obs', 'var'], List[str]]
         Colums to fetch for obs and var dataframes.
 
@@ -64,12 +64,12 @@ def get_anndata(
 
     >>> get_anndata(census, "Homo sapiens", column_names={"obs": ["tissue"]})
 
-    >>> get_anndata(census, "Homo sapiens", obs_coords=(slice(0, 1000),))
+    >>> get_anndata(census, "Homo sapiens", obs_coords=slice(0, 1000))
 
     """
     exp = get_experiment(census, organism)
-    obs_coords = obs_coords or (slice(None),)
-    var_coords = var_coords or (slice(None),)
+    obs_coords = (obs_coords,) if obs_coords else (slice(None),)
+    var_coords = (var_coords,) if var_coords else (slice(None),)
     with exp.axis_query(
         measurement_name,
         obs_query=soma.AxisQuery(value_filter=obs_value_filter, coords=obs_coords),


### PR DESCRIPTION
Because the census has a single index dimension on both axis, we can further refine the get_anndata parameters for simplicity, by assuming a single dim.

Fixes #119 
