### PR TITLE
allows_duplicate schema tuning

### DIFF
--- a/tools/cell_census_builder/__main__.py
+++ b/tools/cell_census_builder/__main__.py
@@ -117,7 +117,7 @@ def build(
         return 1
 
     # Ensure that the git tree is clean
-    if is_git_repo_dirty():
+    if not args.test_disable_dirty_git_check and is_git_repo_dirty():
         logging.error("The git repo has uncommitted changes - aborting build")
         return 1
 
@@ -313,8 +313,12 @@ def create_args_parser() -> argparse.ArgumentParser:
         default=True,
         help="Consolidate TileDB objects after build",
     )
-    # hidden option for testing. Will process only the first 'n' datasets
+    # hidden option for testing by devs. Will process only the first 'n' datasets
     build_parser.add_argument("--test-first-n", type=int, help=argparse.SUPPRESS)
+    # hidden option for testing by devs. Allow for WIP testing by devs.
+    build_parser.add_argument(
+        "--test-disable-dirty-git-check", action=argparse.BooleanOptionalAction, help=argparse.SUPPRESS
+    )
 
     # VALIDATE
     subparsers.add_parser("validate", help="Validate an existing cell census build")

--- a/tools/cell_census_builder/validate.py
+++ b/tools/cell_census_builder/validate.py
@@ -229,6 +229,20 @@ def validate_axis_dataframes(
         assert eb_info[eb.name].vars == set(census_var_df.feature_id.array)
         assert (len(census_var_df) == 0) or (census_var_df.soma_joinid.max() + 1 == n_vars)
 
+        # Validate that all obs soma_joinids are unique and in the range [0, n).
+        obs_unique_joinids = np.unique(census_obs_df.soma_joinid.to_numpy())
+        assert len(obs_unique_joinids) == len(census_obs_df.soma_joinid.to_numpy())
+        assert (len(obs_unique_joinids) == 0) or (
+            (obs_unique_joinids[0] == 0) and (obs_unique_joinids[-1] == (len(obs_unique_joinids) - 1))
+        )
+
+        # Validate that all var soma_joinids are unique and in the range [0, n).
+        var_unique_joinids = np.unique(census_var_df.soma_joinid.to_numpy())
+        assert len(var_unique_joinids) == len(census_var_df.soma_joinid.to_numpy())
+        assert (len(var_unique_joinids) == 0) or (
+            (var_unique_joinids[0] == 0) and var_unique_joinids[-1] == (len(var_unique_joinids) - 1)
+        )
+
     return True
 
 


### PR DESCRIPTION
SOMA and the Cell Census require that all joinids in the obs/var axes, and all coordinates in the X layers, are unique. By default, the SOMA implementation enforces this constraint at _read_ time, incurring a read performance penalty. The Cell Census builder can guarantee this constraint at write time, providing a read-time performance win.

Changes in this PR:
* enhance validation of obs/var axes and the X layers to explicitly confirm this constraint.

WIP still to come:
* set the schema parameter `allows_duplicates` on the axes DataFrames and X SparseNDArrays
