### PR TITLE
Report cell census changes between versions

### DIFF
--- a/tools/cell_census_builder/scripts/release/census_summary.py
+++ b/tools/cell_census_builder/scripts/release/census_summary.py
@@ -48,15 +48,13 @@ if __name__ == "__main__":
         removed_datasets = prev_dataset_ids - curr_datasets_ids
         if added_datasets:
             print("Datasets that were added")
-            for d in added_datasets:
-                print(d)
-                print()
+            added_datasets_df = curr_datasets[curr_datasets["dataset_id"].isin(added_datasets)]
+            print(added_datasets_df[["dataset_id", "dataset_title", "collection_name"]])
 
         if removed_datasets:
             print("Datasets that were removed")
-            for d in removed_datasets:
-                print(d)
-                print()
+            removed_datasets_df = prev_datasets[prev_datasets["dataset_id"].isin(removed_datasets)]
+            print(removed_datasets_df[["dataset_id", "dataset_title", "collection_name"]])
 
         # Datasets in both versions but that have differing cell counts
         joined = prev_datasets.join(

--- a/tools/cell_census_builder/scripts/release/census_summary.py
+++ b/tools/cell_census_builder/scripts/release/census_summary.py
@@ -1,3 +1,4 @@
+import argparse
 import sys
 
 import cell_census
@@ -5,10 +6,8 @@ import pandas as pd
 
 from tools.cell_census_builder.globals import CENSUS_DATA_NAME, CENSUS_INFO_NAME
 
-if __name__ == "__main__":
-    census_version = sys.argv[1] if len(sys.argv) > 1 else "latest"
-    previous_census_version = sys.argv[2] if len(sys.argv) > 2 else None
 
+def display_summary(census_version: str) -> int:
     census = cell_census.open_soma(census_version=census_version)
 
     COLS_TO_QUERY = [
@@ -32,100 +31,136 @@ if __name__ == "__main__":
     print(display_stats_df)
     print()
 
-    # Calculate the diff with respect to the previous version (if specified)
+    return 0
 
-    if previous_census_version is not None:
-        previous_census = cell_census.open_soma(census_version=previous_census_version)
 
-        prev_datasets = previous_census[CENSUS_INFO_NAME]["datasets"].read().concat().to_pandas()
-        curr_datasets = census[CENSUS_INFO_NAME]["datasets"].read().concat().to_pandas()
+def display_diff(census_version: str, previous_census_version: str) -> int:
+    census = cell_census.open_soma(census_version=census_version)
+    previous_census = cell_census.open_soma(census_version=previous_census_version)
 
-        # Datasets removed, added
-        curr_datasets_ids = set(curr_datasets["dataset_id"])
-        prev_dataset_ids = set(prev_datasets["dataset_id"])
+    prev_datasets = previous_census[CENSUS_INFO_NAME]["datasets"].read().concat().to_pandas()
+    curr_datasets = census[CENSUS_INFO_NAME]["datasets"].read().concat().to_pandas()
 
-        added_datasets = curr_datasets_ids - prev_dataset_ids
-        removed_datasets = prev_dataset_ids - curr_datasets_ids
-        if added_datasets:
-            print("Datasets that were added")
-            added_datasets_df = curr_datasets[curr_datasets["dataset_id"].isin(added_datasets)]
-            print(added_datasets_df[["dataset_id", "dataset_title", "collection_name"]])
-        else:
-            print("No datasets were added")
+    # Datasets removed, added
+    curr_datasets_ids = set(curr_datasets["dataset_id"])
+    prev_dataset_ids = set(prev_datasets["dataset_id"])
+
+    added_datasets = curr_datasets_ids - prev_dataset_ids
+    removed_datasets = prev_dataset_ids - curr_datasets_ids
+    if added_datasets:
+        print("Datasets that were added")
+        added_datasets_df = curr_datasets[curr_datasets["dataset_id"].isin(added_datasets)]
+        print(added_datasets_df[["dataset_id", "dataset_title", "collection_name"]])
+    else:
+        print("No datasets were added")
+    print()
+
+    if removed_datasets:
+        print("Datasets that were removed")
+        removed_datasets_df = prev_datasets[prev_datasets["dataset_id"].isin(removed_datasets)]
+        print(removed_datasets_df[["dataset_id", "dataset_title", "collection_name"]])
+    else:
+        print("No datasets were removed")
+    print()
+
+    # Datasets in both versions but that have differing cell counts
+    joined = prev_datasets.join(
+        curr_datasets.set_index("dataset_id"), on="dataset_id", lsuffix="_prev", rsuffix="_curr"
+    )
+    datasets_with_different_cell_counts = joined.loc[
+        joined["dataset_total_cell_count_prev"] != joined["dataset_total_cell_count_curr"]
+    ][["dataset_id", "dataset_total_cell_count_prev", "dataset_total_cell_count_curr"]]
+
+    if not datasets_with_different_cell_counts.empty:
+        print("Datasets that have a different cell count")
+        print(datasets_with_different_cell_counts)
         print()
 
-        if removed_datasets:
-            print("Datasets that were removed")
-            removed_datasets_df = prev_datasets[prev_datasets["dataset_id"].isin(removed_datasets)]
-            print(removed_datasets_df[["dataset_id", "dataset_title", "collection_name"]])
-        else:
-            print("No datasets were removed")
-        print()
+    # Total cell count deltas by experiment (mouse, human)
 
-        # Datasets in both versions but that have differing cell counts
-        joined = prev_datasets.join(
-            curr_datasets.set_index("dataset_id"), on="dataset_id", lsuffix="_prev", rsuffix="_curr"
+    for organism in census[CENSUS_DATA_NAME]:
+        curr_count = census[CENSUS_DATA_NAME][organism].obs.count
+        prev_count = previous_census[CENSUS_DATA_NAME][organism].obs.count
+        print(
+            f"Previous {organism} cell count: {prev_count}, current {organism} cell count: {curr_count}, delta {curr_count - prev_count}"
         )
-        datasets_with_different_cell_counts = joined.loc[
-            joined["dataset_total_cell_count_prev"] != joined["dataset_total_cell_count_curr"]
-        ][["dataset_id", "dataset_total_cell_count_prev", "dataset_total_cell_count_curr"]]
+        print()
 
-        if not datasets_with_different_cell_counts.empty:
-            print("Datasets that have a different cell count")
-            print(datasets_with_different_cell_counts)
+    # Deltas between summary_cell_counts dataframes
+    y = census["census_info"]["summary_cell_counts"].read().concat().to_pandas()
+    y = y.set_index(["organism", "category", "ontology_term_id"])
+
+    z = previous_census["census_info"]["summary_cell_counts"].read().concat().to_pandas()
+    z = z.set_index(["organism", "category", "ontology_term_id"])
+
+    w = y.join(z, lsuffix="_prev", rsuffix="_curr")
+    delta = w.loc[w["total_cell_count_prev"] != w["total_cell_count_curr"]][
+        ["total_cell_count_prev", "total_cell_count_curr"]
+    ].reset_index()
+    if not delta.empty:
+        print("Summary delta - total cell counts")
+        print(delta)
+        print()
+
+    delta = w.loc[w["unique_cell_count_prev"] != w["unique_cell_count_curr"]][
+        ["unique_cell_count_prev", "unique_cell_count_curr"]
+    ].reset_index()
+    if not delta.empty:
+        print("Summary delta - unique cell counts")
+        print(delta)
+        print()
+
+    # Genes removed, added
+    for organism in census[CENSUS_DATA_NAME]:
+        curr_genes = census[CENSUS_DATA_NAME][organism].ms["RNA"].var.read().concat().to_pandas()
+        prev_genes = previous_census[CENSUS_DATA_NAME][organism].ms["RNA"].var.read().concat().to_pandas()
+
+        new_genes = set(curr_genes["feature_id"]) - set(prev_genes["feature_id"])
+        if new_genes:
+            print("Genes added")
+            print(new_genes)
+        else:
+            "No genes were added."
             print()
 
-        # Total cell count deltas by experiment (mouse, human)
-
-        for organism in census[CENSUS_DATA_NAME]:
-            curr_count = census[CENSUS_DATA_NAME][organism].obs.count
-            prev_count = previous_census[CENSUS_DATA_NAME][organism].obs.count
-            print(
-                f"Previous {organism} cell count: {prev_count}, current {organism} cell count: {curr_count}, delta {curr_count - prev_count}"
-            )
+        removed_genes = set(prev_genes["feature_id"]) - set(curr_genes["feature_id"])
+        if removed_genes:
+            print("Genes removed")
+            print(removed_genes)
+        else:
+            "No genes were removed."
             print()
 
-        # Deltas between summary_cell_counts dataframes
-        y = census["census_info"]["summary_cell_counts"].read().concat().to_pandas()
-        y = y.set_index(["organism", "category", "ontology_term_id"])
+    return 0
 
-        z = previous_census["census_info"]["summary_cell_counts"].read().concat().to_pandas()
-        z = z.set_index(["organism", "category", "ontology_term_id"])
 
-        w = y.join(z, lsuffix="_prev", rsuffix="_curr")
-        delta = w.loc[w["total_cell_count_prev"] != w["total_cell_count_curr"]][
-            ["total_cell_count_prev", "total_cell_count_curr"]
-        ].reset_index()
-        if not delta.empty:
-            print("Summary delta - total cell counts")
-            print(delta)
-            print()
+def create_args_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="cell_census_summary")
+    parser.add_argument("-c", "--census-version", default="latest", help="Version of the census. Defaults to latest")
+    subparsers = parser.add_subparsers(required=True, dest="subcommand")
 
-        delta = w.loc[w["unique_cell_count_prev"] != w["unique_cell_count_curr"]][
-            ["unique_cell_count_prev", "unique_cell_count_curr"]
-        ].reset_index()
-        if not delta.empty:
-            print("Summary delta - unique cell counts")
-            print(delta)
-            print()
+    # BUILD
+    subparsers.add_parser("summarize", help="Summarize the cell census")
 
-        # Genes removed, added
-        for organism in census[CENSUS_DATA_NAME]:
-            curr_genes = census[CENSUS_DATA_NAME][organism].ms["RNA"].var.read().concat().to_pandas()
-            prev_genes = previous_census[CENSUS_DATA_NAME][organism].ms["RNA"].var.read().concat().to_pandas()
+    # VALIDATE
+    diff_parser = subparsers.add_parser("diff", help="Shows the diff with a previous census version")
+    diff_parser.add_argument("-p", "--previous-version", help="Version of the census to diff")
 
-            new_genes = set(curr_genes["feature_id"]) - set(prev_genes["feature_id"])
-            if new_genes:
-                print("Genes added")
-                print(new_genes)
-            else:
-                "No genes were added."
-                print()
+    return parser
 
-            removed_genes = set(prev_genes["feature_id"]) - set(curr_genes["feature_id"])
-            if removed_genes:
-                print("Genes removed")
-                print(removed_genes)
-            else:
-                "No genes were removed."
-                print()
+
+def main() -> int:
+    parser = create_args_parser()
+    args = parser.parse_args()
+    assert args.subcommand in ["summarize", "diff"]
+
+    if args.subcommand == "summarize":
+        return display_summary(args.census_version)
+    elif args.subcommand == "diff":
+        return display_diff(args.census_version, args.previous_version)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/cell_census_builder/scripts/release/census_summary.py
+++ b/tools/cell_census_builder/scripts/release/census_summary.py
@@ -50,11 +50,17 @@ if __name__ == "__main__":
             print("Datasets that were added")
             added_datasets_df = curr_datasets[curr_datasets["dataset_id"].isin(added_datasets)]
             print(added_datasets_df[["dataset_id", "dataset_title", "collection_name"]])
+        else:
+            print("No datasets were added")
+        print()
 
         if removed_datasets:
             print("Datasets that were removed")
             removed_datasets_df = prev_datasets[prev_datasets["dataset_id"].isin(removed_datasets)]
             print(removed_datasets_df[["dataset_id", "dataset_title", "collection_name"]])
+        else:
+            print("No datasets were removed")
+        print()
 
         # Datasets in both versions but that have differing cell counts
         joined = prev_datasets.join(
@@ -70,9 +76,10 @@ if __name__ == "__main__":
             print()
 
         # Total cell count deltas by experiment (mouse, human)
-        for organism in ["homo_sapiens", "mus_musculus"]:
-            curr_count = census[CENSUS_DATA_NAME][organism]["obs"].count
-            prev_count = previous_census[CENSUS_DATA_NAME][organism]["obs"].count
+
+        for organism in census[CENSUS_DATA_NAME]:
+            curr_count = census[CENSUS_DATA_NAME][organism].obs.count
+            prev_count = previous_census[CENSUS_DATA_NAME][organism].obs.count
             print(
                 f"Previous {organism} cell count: {prev_count}, current {organism} cell count: {curr_count}, delta {curr_count - prev_count}"
             )
@@ -103,18 +110,22 @@ if __name__ == "__main__":
             print()
 
         # Genes removed, added
-        for organism in ["homo_sapiens", "mus_musculus"]:
-            curr_genes = census[CENSUS_DATA_NAME][organism]["ms"]["RNA"]["var"].read().concat().to_pandas()
-            prev_genes = previous_census[CENSUS_DATA_NAME][organism]["ms"]["RNA"]["var"].read().concat().to_pandas()
+        for organism in census[CENSUS_DATA_NAME]:
+            curr_genes = census[CENSUS_DATA_NAME][organism].ms["RNA"].var.read().concat().to_pandas()
+            prev_genes = previous_census[CENSUS_DATA_NAME][organism].ms["RNA"].var.read().concat().to_pandas()
 
             new_genes = set(curr_genes["feature_id"]) - set(prev_genes["feature_id"])
             if new_genes:
                 print("Genes added")
-                new_genes
+                print(new_genes)
+            else:
+                "No genes were added."
                 print()
 
             removed_genes = set(prev_genes["feature_id"]) - set(curr_genes["feature_id"])
             if removed_genes:
                 print("Genes removed")
-                removed_genes
+                print(removed_genes)
+            else:
+                "No genes were removed."
                 print()

--- a/tools/cell_census_builder/scripts/release/census_summary.py
+++ b/tools/cell_census_builder/scripts/release/census_summary.py
@@ -2,10 +2,12 @@ import sys
 
 import cell_census
 import pandas as pd
-from cell_census_builder.globals import CENSUS_DATA_NAME
+
+from tools.cell_census_builder.globals import CENSUS_DATA_NAME, CENSUS_INFO_NAME
 
 if __name__ == "__main__":
     census_version = sys.argv[1] if len(sys.argv) > 1 else "latest"
+    previous_census_version = sys.argv[2] if len(sys.argv) > 2 else None
 
     census = cell_census.open_soma(census_version=census_version)
 
@@ -28,3 +30,33 @@ if __name__ == "__main__":
     stats_df = pd.DataFrame(stats, columns=["organism", "attribute", "unique count"])
     display_stats_df = pd.pivot(stats_df, index=["organism"], columns=["attribute"], values=["unique count"])
     print(display_stats_df)
+
+    # Calculate the diff with respect to the previous version (if specified)
+
+    if previous_census_version is not None:
+        previous_census = cell_census.open_soma(census_version=previous_census_version)
+
+        prev_datasets = previous_census[CENSUS_INFO_NAME]["datasets"].read().concat().to_pandas()
+        curr_datasets = census[CENSUS_INFO_NAME]["datasets"].read().concat().to_pandas()
+
+        # Datasets removed, added
+
+        curr_datasets_ids = set(curr_datasets["dataset_id"])
+        prev_dataset_ids = set(prev_datasets["dataset_id"])
+
+        print("Datasets that were added")
+        print(curr_datasets_ids - prev_dataset_ids)
+
+        print("Datasets that were removed")
+        print(prev_dataset_ids - curr_datasets_ids)
+
+        # Datasets in both versions but that have differing cell counts
+        # Total cell count deltas by experiment (mouse, human)
+        # Deltas between summary_cell_counts dataframes
+        # Genes removed, added
+
+        print(prev_datasets.columns)
+        # print(curr_datasets)
+
+        print("DIFF")
+        print(curr_datasets["dataset_ids"] - prev_datasets)

--- a/tools/cell_census_builder/scripts/release/census_summary.py
+++ b/tools/cell_census_builder/scripts/release/census_summary.py
@@ -30,6 +30,7 @@ if __name__ == "__main__":
     stats_df = pd.DataFrame(stats, columns=["organism", "attribute", "unique count"])
     display_stats_df = pd.pivot(stats_df, index=["organism"], columns=["attribute"], values=["unique count"])
     print(display_stats_df)
+    print()
 
     # Calculate the diff with respect to the previous version (if specified)
 
@@ -49,11 +50,13 @@ if __name__ == "__main__":
             print("Datasets that were added")
             for d in added_datasets:
                 print(d)
+                print()
 
         if removed_datasets:
             print("Datasets that were removed")
             for d in removed_datasets:
                 print(d)
+                print()
 
         # Datasets in both versions but that have differing cell counts
         joined = prev_datasets.join(
@@ -66,6 +69,7 @@ if __name__ == "__main__":
         if not datasets_with_different_cell_counts.empty:
             print("Datasets that have a different cell count")
             print(datasets_with_different_cell_counts)
+            print()
 
         # Total cell count deltas by experiment (mouse, human)
         for organism in ["homo_sapiens", "mus_musculus"]:
@@ -74,8 +78,31 @@ if __name__ == "__main__":
             print(
                 f"Previous {organism} cell count: {prev_count}, current {organism} cell count: {curr_count}, delta {curr_count - prev_count}"
             )
+            print()
 
         # Deltas between summary_cell_counts dataframes
+        y = census["census_info"]["summary_cell_counts"].read().concat().to_pandas()
+        y = y.set_index(["organism", "category", "ontology_term_id"])
+
+        z = previous_census["census_info"]["summary_cell_counts"].read().concat().to_pandas()
+        z = z.set_index(["organism", "category", "ontology_term_id"])
+
+        w = y.join(z, lsuffix="_prev", rsuffix="_curr")
+        delta = w.loc[w["total_cell_count_prev"] != w["total_cell_count_curr"]][
+            ["total_cell_count_prev", "total_cell_count_curr"]
+        ].reset_index()
+        if not delta.empty:
+            print("Summary delta - total cell counts")
+            print(delta)
+            print()
+
+        delta = w.loc[w["unique_cell_count_prev"] != w["unique_cell_count_curr"]][
+            ["unique_cell_count_prev", "unique_cell_count_curr"]
+        ].reset_index()
+        if not delta.empty:
+            print("Summary delta - unique cell counts")
+            print(delta)
+            print()
 
         # Genes removed, added
         for organism in ["homo_sapiens", "mus_musculus"]:
@@ -86,8 +113,10 @@ if __name__ == "__main__":
             if new_genes:
                 print("Genes added")
                 new_genes
+                print()
 
             removed_genes = set(prev_genes["feature_id"]) - set(curr_genes["feature_id"])
             if removed_genes:
                 print("Genes removed")
                 removed_genes
+                print()


### PR DESCRIPTION
The `census_summary` script can now be used to generate a diff

Example usage: 

```python -m tools.cell_census_builder.scripts.release.census_summary -c 2023-02-06 diff -p 2023-01-30```

Example output:

```
Datasets that were added
d7d7e89c-c93a-422d-8958-9b4a90b69558

3c75a463-6a87-4132-83a8-c3002624394d

5500c673-1610-40a0-86d9-64d987ae50e6

a5d95a42-0137-496f-8a60-101e17f263c8

Previous homo_sapiens cell count: 43246174, current homo_sapiens cell count: 43420131, delta 173957

Previous mus_musculus cell count: 3922090, current mus_musculus cell count: 3922090, delta 0
```

Other cases are computed but only displayed if the difference is not null.