### PR TITLE
fix: builder no longer expects dataset_title in collection response

### DIFF
--- a/tools/cell_census_builder/manifest.py
+++ b/tools/cell_census_builder/manifest.py
@@ -60,7 +60,6 @@ def load_manifest_from_CxG() -> List[Dataset]:
             "collection_id": collection["id"],
             "collection_name": null_to_empty_str(collection["name"]),
             "collection_doi": null_to_empty_str(collection["doi"]),
-            "dataset_title": dataset["title"],
             "dataset_id": dataset["id"],
         }
         for collection in collections


### PR DESCRIPTION
Fixes #161 

Changes:
Remove parsing of dataset_title from Discover API collection response; the attribute is not provided there; it is provided in the individual responses made for each dataset

Testing:
Tested 1-line code removal earlier on EC2 instance. Did not test this change again after making the PR, but upcoming census build will confirm.

Did NOT add a test, as this was done in another [issue](https://github.com/chanzuckerberg/cell-census/issues/111) that more thoroughly tests.