### PR TITLE
Change docstrings to use Google conventions

### DIFF
--- a/api/python/cell_census/src/cell_census/_experiment.py
+++ b/api/python/cell_census/src/cell_census/_experiment.py
@@ -21,14 +21,16 @@ def _get_experiment(census: soma.Collection, organism: str) -> soma.Experiment:
     [lifecycle: experimental]
 
     Args:
-        census: soma.Collection, The census
-        organism: str, The organism name, eg., ``Homo sapiens``
+        census: soma.Collection
+            The census.
+        organism: str
+            The organism name, eg., ``Homo sapiens``.
 
     Returns:
         A soma.Experiment object with the requested experiment.
 
     Raises:
-        ValueError: if unable to find the specified organism
+        ValueError: if unable to find the specified organism.
 
     Examples:
 

--- a/api/python/cell_census/src/cell_census/_experiment.py
+++ b/api/python/cell_census/src/cell_census/_experiment.py
@@ -1,33 +1,42 @@
+# Copyright (c) 2022-2023 Chan Zuckerberg Initiative
+#
+# Licensed under the MIT License.
+
+"""
+Experiments handler.
+
+Contains methods to retrieve SOMA Experiments.
+"""
+
 import re
 
 import tiledbsoma as soma
 
 
 def _get_experiment(census: soma.Collection, organism: str) -> soma.Experiment:
-    """
-    Given a census ``soma.Collection``, return the experiment for the named organism.
+    """Given a census ``soma.Collection``, return the experiment for the named organism.
     Organism matching is somewhat flexible, attempting to map from human-friendly
-    names to the underlying collection element name.  Will raise a ``ValueError`` if
-    unable to find the specified organism [lifecycle: experimental].
+    names to the underlying collection element name.
 
-    Parameters
-    ----------
-    census - ``soma.Collection``
-        The census
-    organism - ``str``
-        The organism name, eg., ``Homo sapiens``
+    [lifecycle: experimental]
 
-    Returns
-    -------
-    ``soma.Experiment`` - the requested experiment.
+    Args:
+        census: soma.Collection, The census
+        organism: str, The organism name, eg., ``Homo sapiens``
 
-    Examples
-    --------
-    >>> human = get_experiment(census, 'homo sapiens')
+    Returns:
+        A soma.Experiment object with the requested experiment.
 
-    >>> human = get_experiment(census, 'Homo sapiens')
+    Raises:
+        ValueError: if unable to find the specified organism
 
-    >>> human = get_experiment(census, 'homo_sapiens')
+    Examples:
+
+        >>> human = get_experiment(census, 'homo sapiens')
+
+        >>> human = get_experiment(census, 'Homo sapiens')
+
+        >>> human = get_experiment(census, 'homo_sapiens')
     """
     # lower/snake case the organism name to find the experiment name
     exp_name = re.sub(r"[ ]+", "_", organism).lower()

--- a/api/python/cell_census/src/cell_census/_get_anndata.py
+++ b/api/python/cell_census/src/cell_census/_get_anndata.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2022-2023 Chan Zuckerberg Initiative
+#
+# Licensed under the MIT License.
+
+"""Get slice as AnnData
+
+Methods to retrieve slices of the census as AnnData objects.
+"""
 from typing import Optional
 
 import anndata
@@ -25,45 +33,32 @@ def get_anndata(
 ) -> anndata.AnnData:
     """
     Convience wrapper around ``soma.Experiment`` query, to build and execute a query,
-    and return it as an ``AnnData`` object [lifecycle: experimental].
+    and return it as an :py:class:`anndata.AnnData` object.
 
-    Parameters
-    ----------
-    census : ``soma.Collection``
-        The census object, usually returned by `cell_census.open_soma()`
-    organism : ``str``
-        The organism to query, usually one of "Homo sapiens" or "Mus musculus"
-    measurement_name : ``str``, default ``"RNA"``
-        The measurement object to query
-    X_name : str, default ``"raw"``
-        The ``X`` layer to query
-    obs_value_filter: ``str``, default ``None``
-        Value filter for the ``obs`` metadata. Value is a filter query written in the
-        SOMA ``value_filter`` syntax.
-    obs_coords: ``tuple``[``int``, slice or NumPy ArrayLike of ``int``], default ``None``
-        Coordinates for the ``obs`` axis, which is indexed by the ``soma_joinid`` value.
-        May be an ``int``, a list of ``int``, or a slice. The default, ``None``, selects all.
-    var_value_filter: ``str``, default ``None``
-        Value filter for the ``var`` metadata. Value is a filter query written in the
-        SOMA ``value_filter`` syntax.
-    var_coords: ``tuple``[``int``, slice or NumPy ArrayLike of ``int``], default ``None``
-        Coordinates for the ``var`` axis, which is indexed by the ``soma_joinid`` value.
-        May be an ``int``, a list of ``int``, or a slice. The default, ``None``, selects all.
-    column_names: ``dict[Literal['obs', 'var'], List[str]]``
-        Colums to fetch for ``obs`` and ``var`` dataframes.
+    [lifecycle: experimental]
 
-    Returns
-    -------
-    ``anndata.AnnData`` - containing the census slice
+    Args:
+        census: The census object, usually returned by :func:`cell_census.open_soma()`.
+        organism: The organism to query, usually one of `Homo sapiens` or `Mus musculus`.
+        measurement_name: The measurement object to query. Defaults to `RNA`.
+        X_name: The ``X`` layer to query. Defaults to `raw`.
+        obs_value_filter: Value filter for the ``obs`` metadata. Value is a filter query written in the
+            SOMA ``value_filter`` syntax.
+        obs_coords: Coordinates for the ``obs`` axis, which is indexed by the ``soma_joinid`` value.
+            May be an ``int``, a list of ``int``, or a slice. The default, ``None``, selects all.
+        var_value_filter: Value filter for the ``var`` metadata. Value is a filter query written in the
+            SOMA ``value_filter`` syntax.
+        var_coords: Coordinates for the ``var`` axis, which is indexed by the ``soma_joinid`` value.
+            May be an ``int``, a list of ``int``, or a slice. The default, ``None``, selects all.
+        column_names: Colums to fetch for ``obs`` and ``var`` dataframes.
 
-    Examples
-    --------
-    >>> get_anndata(census, "Mus musculus", obs_value_filter="tissue_general in ['brain', 'lung']")
+    Returns:
+        An :py:class:`anndata.AnnData` object containing the census slice.
 
-    >>> get_anndata(census, "Homo sapiens", column_names={"obs": ["tissue"]})
-
-    >>> get_anndata(census, "Homo sapiens", obs_coords=slice(0, 1000))
-
+    Examples:
+        >>> get_anndata(census, "Mus musculus", obs_value_filter="tissue_general in ['brain', 'lung']")
+        >>> get_anndata(census, "Homo sapiens", column_names={"obs": ["tissue"]})
+        >>> get_anndata(census, "Homo sapiens", obs_coords=slice(0, 1000))
     """
     exp = _get_experiment(census, organism)
     obs_coords = (slice(None),) if obs_coords is None else (obs_coords,)

--- a/api/python/cell_census/src/cell_census/_get_anndata.py
+++ b/api/python/cell_census/src/cell_census/_get_anndata.py
@@ -38,19 +38,28 @@ def get_anndata(
     [lifecycle: experimental]
 
     Args:
-        census: The census object, usually returned by :func:`cell_census.open_soma()`.
-        organism: The organism to query, usually one of `Homo sapiens` or `Mus musculus`.
-        measurement_name: The measurement object to query. Defaults to `RNA`.
-        X_name: The ``X`` layer to query. Defaults to `raw`.
-        obs_value_filter: Value filter for the ``obs`` metadata. Value is a filter query written in the
+        census:
+            The census object, usually returned by :func:`cell_census.open_soma()`.
+        organism:
+            The organism to query, usually one of `Homo sapiens` or `Mus musculus`.
+        measurement_name:
+            The measurement object to query. Defaults to `RNA`.
+        X_name:
+            The ``X`` layer to query. Defaults to `raw`.
+        obs_value_filter:
+            Value filter for the ``obs`` metadata. Value is a filter query written in the
             SOMA ``value_filter`` syntax.
-        obs_coords: Coordinates for the ``obs`` axis, which is indexed by the ``soma_joinid`` value.
+        obs_coords:
+            Coordinates for the ``obs`` axis, which is indexed by the ``soma_joinid`` value.
             May be an ``int``, a list of ``int``, or a slice. The default, ``None``, selects all.
-        var_value_filter: Value filter for the ``var`` metadata. Value is a filter query written in the
+        var_value_filter:
+            Value filter for the ``var`` metadata. Value is a filter query written in the
             SOMA ``value_filter`` syntax.
-        var_coords: Coordinates for the ``var`` axis, which is indexed by the ``soma_joinid`` value.
+        var_coords:
+            Coordinates for the ``var`` axis, which is indexed by the ``soma_joinid`` value.
             May be an ``int``, a list of ``int``, or a slice. The default, ``None``, selects all.
-        column_names: Columns to fetch for ``obs`` and ``var`` dataframes.
+        column_names:
+            Columns to fetch for ``obs`` and ``var`` dataframes.
 
     Returns:
         An :class:`anndata.AnnData` object containing the census slice.

--- a/api/python/cell_census/src/cell_census/_get_anndata.py
+++ b/api/python/cell_census/src/cell_census/_get_anndata.py
@@ -33,7 +33,7 @@ def get_anndata(
 ) -> anndata.AnnData:
     """
     Convience wrapper around ``soma.Experiment`` query, to build and execute a query,
-    and return it as an :py:class:`anndata.AnnData` object.
+    and return it as an :class:`anndata.AnnData` object.
 
     [lifecycle: experimental]
 
@@ -50,14 +50,16 @@ def get_anndata(
             SOMA ``value_filter`` syntax.
         var_coords: Coordinates for the ``var`` axis, which is indexed by the ``soma_joinid`` value.
             May be an ``int``, a list of ``int``, or a slice. The default, ``None``, selects all.
-        column_names: Colums to fetch for ``obs`` and ``var`` dataframes.
+        column_names: Columns to fetch for ``obs`` and ``var`` dataframes.
 
     Returns:
-        An :py:class:`anndata.AnnData` object containing the census slice.
+        An :class:`anndata.AnnData` object containing the census slice.
 
     Examples:
         >>> get_anndata(census, "Mus musculus", obs_value_filter="tissue_general in ['brain', 'lung']")
+
         >>> get_anndata(census, "Homo sapiens", column_names={"obs": ["tissue"]})
+
         >>> get_anndata(census, "Homo sapiens", obs_coords=slice(0, 1000))
     """
     exp = _get_experiment(census, organism)

--- a/api/python/cell_census/src/cell_census/_open.py
+++ b/api/python/cell_census/src/cell_census/_open.py
@@ -4,7 +4,7 @@
 
 """Open census and related datasets
 
-Contains methods to open the Cell Census object and access its datasets.
+Contains methods to open  publicly hosted versions of Cell Census object and access its source datasets.
 """
 
 import os.path

--- a/api/python/cell_census/src/cell_census/_open.py
+++ b/api/python/cell_census/src/cell_census/_open.py
@@ -56,10 +56,13 @@ def open_soma(
     [lifecycle: experimental]
 
     Args:
-        census_version: The version of the Census, e.g. "latest".
-        uri: The URI containing the Census SOMA objects. If specified, will take precedence
+        census_version:
+            The version of the Census, e.g. "latest".
+        uri:
+            The URI containing the Census SOMA objects. If specified, will take precedence
             over ``census_version`` parameter.
-        context: a custom :class:`SOMATileDBContext`.
+        context:
+            A custom :class:`SOMATileDBContext`.
 
     Returns:
         A SOMA Collection object containing the top-level census.
@@ -70,7 +73,6 @@ def open_soma(
             or a version are specified.
 
     Examples:
-
         Open the default Cell Census version, using a context manager which will automatically
         close the census upon exit of the context.
 
@@ -116,14 +118,16 @@ def get_source_h5ad_uri(dataset_id: str, *, census_version: str = "latest") -> C
     [lifecycle: experimental]
 
     Args:
-        dataset_id: The ``dataset_id`` of interest.
-        census_version: The census version.
+        dataset_id:
+            The ``dataset_id`` of interest.
+        census_version:
+            The census version.
 
     Returns:
-        A :class:`CensusLocator` object that contains the URI and optional S3 region for the source H5AD.
+        A :py:obj:`CensusLocator` object that contains the URI and optional S3 region for the source H5AD.
 
     Raises:
-        KeyError: if either dataset_id or census_version do not exist.
+        KeyError: if either `dataset_id` or `census_version` do not exist.
 
     Examples:
         >>> cell_census.get_source_h5ad_uri("cb5efdb0-f91c-4cbd-9ad4-9d4fa41c572d")
@@ -150,9 +154,12 @@ def download_source_h5ad(dataset_id: str, to_path: str, *, census_version: str =
     [lifecycle: experimental]
 
     Args:
-        dataset_id: Fetch the source (original) H5AD associated with this `dataset_id`.
-        to_path: The file name where the downloaded H5AD will be written.  Must not already exist.
-        census_version: The census version name. Defaults to `latest`.
+        dataset_id
+            Fetch the source (original) H5AD associated with this `dataset_id`.
+        to_path:
+            The file name where the downloaded H5AD will be written.  Must not already exist.
+        census_version:
+            The census version name. Defaults to `latest`.
 
     Raises:
         ValueError: if the path already exists (i.e., will not overwrite

--- a/api/python/cell_census/src/cell_census/_open.py
+++ b/api/python/cell_census/src/cell_census/_open.py
@@ -1,3 +1,12 @@
+# Copyright (c) 2022-2023 Chan Zuckerberg Initiative
+#
+# Licensed under the MIT License.
+
+"""Open census and related datasets
+
+Contains methods to open the Cell Census object and access its datasets.
+"""
+
 import os.path
 import urllib.parse
 from typing import Any, Dict, Optional
@@ -42,54 +51,52 @@ def open_soma(
     uri: Optional[str] = None,
     context: Optional[soma.options.SOMATileDBContext] = None,
 ) -> soma.Collection:
-    """
-    Open the Cell Census by version or URI, returning a ``soma.Collection`` containing the
-    top-level census.  Raises error if ``census_version`` is specified and unknown, or
-    if neither ``uri`` or ``census_version`` are specified, or if the ``uri`` can not
-    be opened [lifecycle: experimental].
+    """Open the Cell Census by version or URI.
 
-    Parameters
-    ----------
-    census_version : ``Optional[str]``
-        The version of the Census, e.g., "latest"
-    uri : Optional[str]
-        The URI containing the Census SOMA objects. If specified, will take precedence
-        over ``census_version`` parameter. An exception will be raised if the URI can
-        not be opened.
+    [lifecycle: experimental]
 
-    Returns
-    -------
-    ``soma.Collection`` : returns a SOMA Collection object. Can be used as a context manager, which
-        will automatically close upon exit.
+    Args:
+        census_version: The version of the Census, e.g. "latest".
+        uri: The URI containing the Census SOMA objects. If specified, will take precedence
+            over ``census_version`` parameter.
+        context: a custom :class:`SOMATileDBContext`.
 
-    Examples
-    --------
-    Open the default Cell Census version, using a context manager which will automatically
-    close the census upon exit of the context.
+    Returns:
+        A SOMA Collection object containing the top-level census.
+        It can be used as a context manager, which will automatically close upon exit.
 
-    >>> with cell_census.open_soma() as census:
+    Raises:
+        ValueError: if the census cannot be found, the URI cannot be opened, or neither a URI
+            or a version are specified.
+
+    Examples:
+
+        Open the default Cell Census version, using a context manager which will automatically
+        close the census upon exit of the context.
+
+        >>> with cell_census.open_soma() as census:
+                ...
+
+        Open and close:
+
+        >>> census = cell_census.open_soma()
             ...
+            census.close()
 
-    Open and close:
+        Open a specific Cell Census by version:
 
-    >>> census = cell_census.open_soma()
-        ...
-        census.close()
+        >>> with cell_census.open_soma("2022-12-31") as census:
+                ...
 
-    Open a specific Cell Census by version:
+        Open a Cell Census by S3 URI, rather than by version.
 
-    >>> with cell_census.open_soma("2022-12-31") as census:
-            ...
+        >>> with cell_census.open_soma(uri="s3://bucket/path") as census:
+                ...
 
-    Open a Cell Census by S3 URI, rather than by version.
+        Open a Cell Census by path (file:// URI), rather than by version.
 
-    >>> with cell_census.open_soma(uri="s3://bucket/path") as census:
-            ...
-
-    Open a Cell Census by path (file:// URI), rather than by version.
-
-    >>> with cell_census.open_soma(uri="/tmp/census") as census:
-            ...
+        >>> with cell_census.open_soma(uri="/tmp/census") as census:
+                ...
     """
 
     if uri is not None:
@@ -103,27 +110,25 @@ def open_soma(
 
 
 def get_source_h5ad_uri(dataset_id: str, *, census_version: str = "latest") -> CensusLocator:
-    """
-    Open the named version of the census, and return the URI for the ``dataset_id``. This
-    does not guarantee that the H5AD exists or is accessible to the user. Raises an
-    error if ``dataset_id`` or ``census_version`` are unknown [lifecycle: experimental].
+    """Open the named version of the census, and return the URI for the ``dataset_id``. This
+    does not guarantee that the H5AD exists or is accessible to the user.
 
-    Parameters
-    ----------
-    dataset_id : ``str``
-        The ``dataset_id`` of interest
-    census_version : ``Optional[str]``
-        The census version
+    [lifecycle: experimental]
 
-    Returns
-    -------
-    ``CensusLocator`` : the URI and optional S3 region for the source H5AD
+    Args:
+        dataset_id: The ``dataset_id`` of interest.
+        census_version: The census version.
 
-    Examples
-    --------
-    >>> cell_census.get_source_h5ad_uri("cb5efdb0-f91c-4cbd-9ad4-9d4fa41c572d")
-    {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/cb5efdb0-f91c-4cbd-9ad4-9d4fa41c572d.h5ad',
-    's3_region': 'us-west-2'}
+    Returns:
+        A :class:`CensusLocator` object that contains the URI and optional S3 region for the source H5AD.
+
+    Raises:
+        KeyError: if either dataset_id or census_version do not exist.
+
+    Examples:
+        >>> cell_census.get_source_h5ad_uri("cb5efdb0-f91c-4cbd-9ad4-9d4fa41c572d")
+        {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/cb5efdb0-f91c-4cbd-9ad4-9d4fa41c572d.h5ad',
+        's3_region': 'us-west-2'}
     """
     description = get_census_version_description(census_version)  # raises
     census = _open_soma(description["soma"])
@@ -139,32 +144,25 @@ def get_source_h5ad_uri(dataset_id: str, *, census_version: str = "latest") -> C
 
 
 def download_source_h5ad(dataset_id: str, to_path: str, *, census_version: str = "latest") -> None:
-    """
-    Download the source H5AD dataset, for the given ``dataset_id``, to the user-specified
-    file name. Will raise an error if the path already exists (i.e., will not overwrite
-    an existing file), or is not a file [lifecycle: experimental].
+    """Download the source H5AD dataset, for the given `dataset_id`, to the user-specified
+    file name.
 
-    Parameters
-    ----------
-    dataset_id : ``str``
-        Fetch the source (original) H5AD associated with this ``dataset_id``.
-    to_path : ``str``
-        The file name where the downloaded H5AD will be written.  Must not already exist.
-    census_version : ``str``
-        The census version name. Defaults to ``latest``.
+    [lifecycle: experimental]
 
-    Returns
-    -------
-    None
+    Args:
+        dataset_id: Fetch the source (original) H5AD associated with this `dataset_id`.
+        to_path: The file name where the downloaded H5AD will be written.  Must not already exist.
+        census_version: The census version name. Defaults to `latest`.
 
-    See Also
-    --------
-    ``get_source_h5ad_uri`` : Look up the location of the source H5AD.
+    Raises:
+        ValueError: if the path already exists (i.e., will not overwrite
+            an existing file), or is not a file.
 
-    Examples
-    --------
-    >>> download_source_h5ad("8e47ed12-c658-4252-b126-381df8d52a3d", to_path="/tmp/data.h5ad")
+    See Also:
+        :func:`get_source_h5ad_uri`: Look up the location of the source H5AD.
 
+    Examples:
+        >>> download_source_h5ad("8e47ed12-c658-4252-b126-381df8d52a3d", to_path="/tmp/data.h5ad")
     """
     if os.path.exists(to_path):
         raise ValueError("Path exists - will not overwrite existing file.")

--- a/api/python/cell_census/src/cell_census/_presence_matrix.py
+++ b/api/python/cell_census/src/cell_census/_presence_matrix.py
@@ -4,7 +4,7 @@
 
 """Presence matrix methods
 
-Methods to retrieve the feature presence matrix.
+Methods to retrieve the feature dataset presence matrix.
 """
 
 import tiledbsoma as soma

--- a/api/python/cell_census/src/cell_census/_presence_matrix.py
+++ b/api/python/cell_census/src/cell_census/_presence_matrix.py
@@ -26,9 +26,12 @@ def get_presence_matrix(
     [lifecycle: experimental]
 
     Args:
-        census: The census from which to read the presence matrix.
-        organism: The organism to query, usually one of `Homo sapiens` or `Mus musculus`.
-        measurement_name: The measurement object to query. Deafults to `RNA`.
+        census:
+            The census from which to read the presence matrix.
+        organism:
+            The organism to query, usually one of `Homo sapiens` or `Mus musculus`.
+        measurement_name:
+            The measurement object to query. Deafults to `RNA`.
 
     Returns:
         A :class:`scipy.sparse.csr_array` object containing the presence matrix.

--- a/api/python/cell_census/src/cell_census/_presence_matrix.py
+++ b/api/python/cell_census/src/cell_census/_presence_matrix.py
@@ -31,7 +31,7 @@ def get_presence_matrix(
         measurement_name: The measurement object to query. Deafults to `RNA`.
 
     Returns:
-        A :py:class:`scipy.sparse.csr_array` object containing the presence matrix.
+        A :class:`scipy.sparse.csr_array` object containing the presence matrix.
 
     Raises:
         ValueError: if the organism cannot be found.
@@ -39,7 +39,7 @@ def get_presence_matrix(
     Examples:
         >>> get_presence_matrix(census, "Homo sapiens", "RNA")
         <321x60554 sparse array of type '<class 'numpy.uint8'>'
-            with 6441269 stored elements in Compressed Sparse Row format>
+        with 6441269 stored elements in Compressed Sparse Row format>
     """
 
     exp = _get_experiment(census, organism)

--- a/api/python/cell_census/src/cell_census/_presence_matrix.py
+++ b/api/python/cell_census/src/cell_census/_presence_matrix.py
@@ -1,3 +1,12 @@
+# Copyright (c) 2022-2023 Chan Zuckerberg Initiative
+#
+# Licensed under the MIT License.
+
+"""Presence matrix methods
+
+Methods to retrieve the feature presence matrix.
+"""
+
 import tiledbsoma as soma
 from scipy import sparse
 
@@ -9,30 +18,27 @@ def get_presence_matrix(
     organism: str,
     measurement_name: str = "RNA",
 ) -> sparse.csr_matrix:
-    """
-    Read the gene presence matrix and return as a SciPy sparse CSR array
-    (``scipy.sparse.csr_array``). The returned sparse matrix is indexed on the
+    """Read the gene presence matrix and return as a SciPy sparse CSR array.
+    The returned sparse matrix is indexed on the
     first dimension by the dataset ``soma_joinid`` values, and on the
-    second dimension by the ``var`` DataFrame ``soma_joinid`` values
-    [lifecycle: experimental].
+    second dimension by the ``var`` DataFrame ``soma_joinid`` values.
 
-    Parameters
-    ----------
-    census : ``soma.Collection``
-        The census from which to read the presence matrix.
-    organism : ``str``
-        The organism to query, usually one of "Homo sapiens" or "Mus musculus"
-    measurement_name : ``str``, default ``"RNA"``
-        The measurement object to query
+    [lifecycle: experimental]
 
-    Returns
-    -------
-    ``scipy.sparse.csr_array`` - containing the presence matrix.
+    Args:
+        census: The census from which to read the presence matrix.
+        organism: The organism to query, usually one of `Homo sapiens` or `Mus musculus`.
+        measurement_name: The measurement object to query. Deafults to `RNA`.
 
-    Examples
-    --------
-    >>> get_presence_matrix(census, "Homo sapiens", "RNA")
-    <321x60554 sparse array of type '<class 'numpy.uint8'>'
+    Returns:
+        A :py:class:`scipy.sparse.csr_array` object containing the presence matrix.
+
+    Raises:
+        ValueError: if the organism cannot be found.
+
+    Examples:
+        >>> get_presence_matrix(census, "Homo sapiens", "RNA")
+        <321x60554 sparse array of type '<class 'numpy.uint8'>'
             with 6441269 stored elements in Compressed Sparse Row format>
     """
 

--- a/api/python/cell_census/src/cell_census/_presence_matrix.py
+++ b/api/python/cell_census/src/cell_census/_presence_matrix.py
@@ -18,7 +18,7 @@ def get_presence_matrix(
     organism: str,
     measurement_name: str = "RNA",
 ) -> sparse.csr_matrix:
-    """Read the gene presence matrix and return as a SciPy sparse CSR array.
+    """Read the feature dataset presence matrix and return as a SciPy sparse CSR array.
     The returned sparse matrix is indexed on the
     first dimension by the dataset ``soma_joinid`` values, and on the
     second dimension by the ``var`` DataFrame ``soma_joinid`` values.

--- a/api/python/cell_census/src/cell_census/_release_directory.py
+++ b/api/python/cell_census/src/cell_census/_release_directory.py
@@ -47,7 +47,8 @@ def get_census_version_description(census_version: str) -> CensusVersionDescript
     [lifecycle: experimental]
 
     Args:
-        census_version: The census version name.
+        census_version:
+            The census version name.
 
     Returns:
         ``CensusVersionDescription`` - a dictionary containing a description of the release.
@@ -76,13 +77,12 @@ def get_census_version_description(census_version: str) -> CensusVersionDescript
 
 def get_census_version_directory() -> Dict[CensusVersionName, CensusVersionDescription]:
     """
-    Get the directory of cell census releases currently available
+    Get the directory of cell census releases currently available.
 
     [lifecycle: experimental]
 
     Returns:
-        ``Dict[CensusVersionName, CensusVersionDescription]`` - Dictionary
-            of release names and their corresponding release description.
+        A dictionary that contains release names and their corresponding release description.
 
     See Also:
         :func:`get_census_version_description`: get description by census_version.

--- a/api/python/cell_census/src/cell_census/_release_directory.py
+++ b/api/python/cell_census/src/cell_census/_release_directory.py
@@ -1,3 +1,12 @@
+# Copyright (c) 2022-2023 Chan Zuckerberg Initiative
+#
+# Licensed under the MIT License.
+
+"""Versioning of Cell Census builds
+
+Methods to retrieve information about the available Cell Census versions.
+"""
+
 from typing import Dict, Optional, Union, cast
 
 import requests
@@ -32,34 +41,31 @@ CELL_CENSUS_RELEASE_DIRECTORY_URL = "https://s3.us-west-2.amazonaws.com/cellxgen
 
 
 def get_census_version_description(census_version: str) -> CensusVersionDescription:
-    """
-    Get release description for given census version, from the Cell
-    Census release directory. Raises KeyError if unknown census_version
-    value [lifecycle: experimental].
+    """Get release description for given census version, from the Cell
+    Census release directory.
 
-    Parameters
-    ----------
-    census_version : ``str``
-        The census version name.
+    [lifecycle: experimental]
 
-    Returns
-    -------
-    ``CensusVersionDescription``
-        Dictionary containing a description of the release.
+    Args:
+        census_version: The census version name.
 
-    See Also
-    --------
-    ``get_census_version_directory`` : returns the entire directory as a dict.
+    Returns:
+        ``CensusVersionDescription`` - a dictionary containing a description of the release.
 
-    Examples
-    --------
-    >>> cell_census.get_census_version_description("latest")
-    {'release_date': None,
-    'release_build': '2022-12-01',
-    'soma': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/soma/',
-    's3_region': 'us-west-2'},
-    'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/',
-    's3_region': 'us-west-2'}}
+    Raises:
+        KeyError: if unknown census_version value.
+
+    See Also:
+        :func:`get_census_version_directory`: returns the entire directory as a dict.
+
+    Examples:
+        >>> cell_census.get_census_version_description("latest")
+        {'release_date': None,
+        'release_build': '2022-12-01',
+        'soma': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/soma/',
+        's3_region': 'us-west-2'},
+        'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/',
+        's3_region': 'us-west-2'}}
     """
     census_directory = get_census_version_directory()
     description = census_directory.get(census_version, None)
@@ -70,43 +76,37 @@ def get_census_version_description(census_version: str) -> CensusVersionDescript
 
 def get_census_version_directory() -> Dict[CensusVersionName, CensusVersionDescription]:
     """
-    Get the directory of cell census releases currently available [lifecycle: experimental].
+    Get the directory of cell census releases currently available
 
-    Parameters
-    ----------
-    None
+    [lifecycle: experimental]
 
-    Returns
-    -------
-    ``Dict[CensusVersionName, CensusVersionDescription]``
-        Dictionary of release names and their corresponding
-        release description.
+    Returns:
+        ``Dict[CensusVersionName, CensusVersionDescription]`` - Dictionary
+            of release names and their corresponding release description.
 
-    See Also
-    --------
-    ``get_census_version_description`` : get description by census_version.
+    See Also:
+        :func:`get_census_version_description`: get description by census_version.
 
-    Examples
-    --------
-    >>> cell_census.get_census_version_directory()
-    {'latest': {'release_date': None,
-    'release_build': '2022-12-01',
-    'soma': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/soma/',
-    's3_region': 'us-west-2'},
-    'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/',
-    's3_region': 'us-west-2'}},
-    '2022-12-01': {'release_date': None,
-    'release_build': '2022-12-01',
-    'soma': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/soma/',
-    's3_region': 'us-west-2'},
-    'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/',
-    's3_region': 'us-west-2'}},
-    '2022-11-29': {'release_date': None,
-    'release_build': '2022-11-29',
-    'soma': {'uri': 's3://cellxgene-data-public/cell-census/2022-11-29/soma/',
-    's3_region': 'us-west-2'},
-    'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2022-11-29/h5ads/',
-    's3_region': 'us-west-2'}}}
+    Examples:
+        >>> cell_census.get_census_version_directory()
+        {'latest': {'release_date': None,
+        'release_build': '2022-12-01',
+        'soma': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/soma/',
+        's3_region': 'us-west-2'},
+        'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/',
+        's3_region': 'us-west-2'}},
+        '2022-12-01': {'release_date': None,
+        'release_build': '2022-12-01',
+        'soma': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/soma/',
+        's3_region': 'us-west-2'},
+        'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2022-12-01/h5ads/',
+        's3_region': 'us-west-2'}},
+        '2022-11-29': {'release_date': None,
+        'release_build': '2022-11-29',
+        'soma': {'uri': 's3://cellxgene-data-public/cell-census/2022-11-29/soma/',
+        's3_region': 'us-west-2'},
+        'h5ads': {'uri': 's3://cellxgene-data-public/cell-census/2022-11-29/h5ads/',
+        's3_region': 'us-west-2'}}}
     """
     response = requests.get(CELL_CENSUS_RELEASE_DIRECTORY_URL)
     response.raise_for_status()

--- a/api/python/cell_census/src/cell_census/_release_directory.py
+++ b/api/python/cell_census/src/cell_census/_release_directory.py
@@ -4,7 +4,7 @@
 
 """Versioning of Cell Census builds
 
-Methods to retrieve information about the available Cell Census versions.
+Methods to retrieve information about versions of the publicly hosted Cell Census object.
 """
 
 from typing import Dict, Optional, Union, cast

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ release = "0.5.0"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['sphinx.ext.autodoc', "nbsphinx", "sphinx.ext.intersphinx"]
+extensions = ['sphinx.ext.autodoc', "nbsphinx", "sphinx.ext.intersphinx", 'sphinx.ext.napoleon']
 
 tiledb_version = "latest"
 
@@ -26,7 +26,10 @@ intersphinx_mapping = {
         % tiledb_version,
         None,
     ),
-    'python': ('https://docs.python.org/3', None)
+    'python': ('https://docs.python.org/3', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy', None),
+    'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
+    'anndata': ('https://anndata.readthedocs.io/en/latest/', None),
 }
 
 templates_path = ['_templates']

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -1,7 +1,7 @@
 .. meta::
    :name=robots: noindex
 
-cell-census Python API Reference
+Python API
 ==============================
 
 Open/retrieve Cell Census data


### PR DESCRIPTION
Notes: 
1. The docstrings at the beginning of each module could use some work. That said, the modules generally only contain 1-2 functions, and the examples are defined in the functions.
2. I removed type annotations from `Args`. They are only recommended if the functions lack type annotations, which is not our case. I think removing them helps with the readability, but we can add them back.