### PR TITLE
fix presence matrix wrong shape

### DIFF
--- a/tools/cell_census_builder/__main__.py
+++ b/tools/cell_census_builder/__main__.py
@@ -295,7 +295,7 @@ def build_step4_populate_X_layers(
     populate_X_layers(assets_path, filtered_datasets, experiment_builders, args)
 
     for eb in reopen_experiment_builders(experiment_builders):
-        eb.populate_presence_matrix()
+        eb.populate_presence_matrix(filtered_datasets)
 
     logging.info("Build step 4 - Populate X layers - finished")
 

--- a/tools/cell_census_builder/experiment_builder.py
+++ b/tools/cell_census_builder/experiment_builder.py
@@ -254,7 +254,7 @@ class ExperimentBuilder:
                     platform_config=CENSUS_X_LAYERS_PLATFORM_CONFIG[layer_name],
                 )
 
-    def populate_presence_matrix(self) -> None:
+    def populate_presence_matrix(self, datasets: List[Dataset]) -> None:
         """
         Save presence matrix per Experiment
         """
@@ -265,7 +265,7 @@ class ExperimentBuilder:
             # sanity check
             assert len(self.presence) == self.n_datasets
 
-            max_dataset_joinid = max(self.presence.keys())
+            max_dataset_joinid = max(d.soma_joinid for d in datasets)
 
             # LIL is fast way to create spmatrix
             pm = sparse.lil_array((max_dataset_joinid + 1, self.n_var), dtype=bool)

--- a/tools/cell_census_builder/tests/test_builder.py
+++ b/tools/cell_census_builder/tests/test_builder.py
@@ -82,6 +82,8 @@ def test_base_builder_creation(
             # Presence matrix should exist with the correct dimensions
             for exp_name in ["homo_sapiens", "mus_musculus"]:
                 fdpm = census[CENSUS_DATA_NAME][exp_name].ms[MEASUREMENT_RNA_NAME][FEATURE_DATASET_PRESENCE_MATRIX_NAME]
+                fdpm_matrix = fdpm.read().coos().concat()
+                assert fdpm_matrix.shape[0] == 4  # 4 datasets
                 fdpm_df = fdpm.read().tables().concat().to_pandas()
                 n_datasets = fdpm_df["soma_dim_0"].nunique()
                 n_features = fdpm_df["soma_dim_1"].nunique()


### PR DESCRIPTION
Reverts a [change](https://github.com/chanzuckerberg/cell-census/commit/85bf654ebdfae67a64135b086a078b27bf041715#diff-32913cbb027d8f5e52f9ab54e24145dcb765c97d8ad2e6165e45625fade18e39R268) that introduced a bug that led the presence matrix to have an incorrect shape.

Per [the cell-census schema specification](https://github.com/chanzuckerberg/cell-census/blob/main/docs/cell_census_schema.md#feature-dataset-presence-matrix--census_objcensus_dataorganismmsrnafeature_dataset_presence_matrix--somasparsendarray), the presence matrix needs to have N rows where N is the number of datasets belonging to the experiment. Since this is a sparse matrix, its _domain_ will extend to the total number of datasets (i.e. `max(d.soma_joinid for d in datasets)`), therefore the shape of the presence matrix (for each experiment) should equal the total number of datasets.
