### PR TITLE
refactor ExperimentBuilder and validator for improved validator isolation

### DIFF
--- a/tools/cell_census_builder/__main__.py
+++ b/tools/cell_census_builder/__main__.py
@@ -149,9 +149,6 @@ def build(
     # Step 5- write out dataset manifest and summary information
     build_step5_populate_summary_info(root_collection, experiment_builders, filtered_datasets, args.build_tag)
 
-    for eb in experiment_builders:
-        eb.build_completed = True
-
     # consolidate TileDB data
     if args.consolidate:
         consolidate(args, root_collection.uri)

--- a/tools/cell_census_builder/__main__.py
+++ b/tools/cell_census_builder/__main__.py
@@ -13,7 +13,12 @@ from .anndata import open_anndata
 from .census_summary import create_census_summary
 from .consolidate import consolidate
 from .datasets import Dataset, assign_dataset_soma_joinids, create_dataset_manifest
-from .experiment_builder import ExperimentBuilder, populate_X_layers, reopen_experiment_builders
+from .experiment_builder import (
+    ExperimentBuilder,
+    ExperimentSpecification,
+    populate_X_layers,
+    reopen_experiment_builders,
+)
 from .globals import (
     CENSUS_DATA_NAME,
     CENSUS_INFO_NAME,
@@ -30,7 +35,7 @@ from .util import get_git_commit_sha, is_git_repo_dirty, uricat
 from .validate import validate
 
 
-def make_experiment_builders() -> List[ExperimentBuilder]:
+def make_experiment_specs() -> List[ExperimentSpecification]:
     """
     Define all soma.Experiments to build in the census.
 
@@ -46,20 +51,18 @@ def make_experiment_builders() -> List[ExperimentBuilder]:
         GENE_LENGTH_BASE_URI + "genes_mus_musculus.csv.gz",
         GENE_LENGTH_BASE_URI + "genes_sars_cov_2.csv.gz",
     ]
-    experiment_builders = [  # The soma.Experiments we want to build
-        ExperimentBuilder(
+    return [  # The soma.Experiments we want to build
+        ExperimentSpecification.create(
             name="homo_sapiens",
             anndata_cell_filter_spec=dict(organism_ontology_term_id="NCBITaxon:9606", assay_ontology_term_ids=RNA_SEQ),
             gene_feature_length_uris=GENE_LENGTH_URIS,
         ),
-        ExperimentBuilder(
+        ExperimentSpecification.create(
             name="mus_musculus",
             anndata_cell_filter_spec=dict(organism_ontology_term_id="NCBITaxon:10090", assay_ontology_term_ids=RNA_SEQ),
             gene_feature_length_uris=GENE_LENGTH_URIS,
         ),
     ]
-
-    return experiment_builders
 
 
 def main() -> int:
@@ -73,15 +76,16 @@ def main() -> int:
     soma_path = uricat(args.uri, args.build_tag, "soma")
     assets_path = uricat(args.uri, args.build_tag, "h5ads")
 
-    # create the experiment builders
-    experiment_builders = make_experiment_builders()
+    # create the experiment specifications and builders
+    experiment_specifications = make_experiment_specs()
+    experiment_builders = [ExperimentBuilder(spec) for spec in experiment_specifications]
 
     cc = 0
     if args.subcommand == "build":
         cc = build(args, soma_path, assets_path, experiment_builders)
 
     if cc == 0 and (args.subcommand == "validate" or args.validate):
-        validate(args, soma_path, assets_path, experiment_builders)
+        validate(args, soma_path, assets_path, experiment_specifications)
 
     return cc
 

--- a/tools/cell_census_builder/datasets.py
+++ b/tools/cell_census_builder/datasets.py
@@ -69,6 +69,8 @@ def create_dataset_manifest(info_collection: soma.Collection, datasets: List[Dat
     logging.info("Creating dataset_manifest")
     manifest_df = Dataset.to_dataframe(datasets)
     manifest_df = manifest_df[CENSUS_DATASETS_COLUMNS + ["soma_joinid"]]
+    if len(manifest_df) == 0:
+        return
 
     # write to a SOMA dataframe
     with info_collection.add_new_dataframe(

--- a/tools/cell_census_builder/experiment_builder.py
+++ b/tools/cell_census_builder/experiment_builder.py
@@ -133,7 +133,6 @@ class ExperimentBuilder:
         self.experiment_uri: Optional[str] = None  # initialized in create()
         self.global_var_joinids: Optional[pd.DataFrame] = None
         self.presence: Dict[int, Tuple[npt.NDArray[np.bool_], npt.NDArray[np.int64]]] = {}
-        self.build_completed: bool = False
 
     @property
     def name(self) -> str:

--- a/tools/cell_census_builder/experiment_builder.py
+++ b/tools/cell_census_builder/experiment_builder.py
@@ -7,6 +7,7 @@ from contextlib import ExitStack
 from typing import Dict, Generator, List, Optional, Sequence, Tuple, TypedDict, Union, overload
 
 import anndata
+import attrs
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -15,6 +16,7 @@ import somacore
 import tiledbsoma as soma
 from scipy import sparse
 from somacore.options import OpenMode
+from typing_extensions import Self
 
 from .anndata import AnnDataFilterSpec, make_anndata_cell_filter, open_anndata
 from .datasets import Dataset
@@ -65,14 +67,18 @@ def _assert_open_for_write(obj: somacore.SOMAObject) -> None:
     assert not obj.closed
 
 
-class ExperimentBuilder:
+@attrs.define(frozen=True)
+class ExperimentSpecification:
     """
-    Class to help build a parameterized SOMA experiment, where key parameters are:
+    Declarative "specification" of a SOMA experiment. This is a read-only
+    specification, independent of the datasets used to build the census.
+
+    Parameters:
     * experiment "name" (eg, 'human'), must be unique in all experiments.
     * an AnnData filter used to cherry pick data for the experiment
-    * methods to progressively build the experiment
+    * external reference data used to build the experiment, e.g., gene length data
 
-    The creation and driving of these objects is done by the main loop.
+    Usage: to create, use the factory method `ExperimentSpecification.create(...)`
     """
 
     name: str
@@ -80,10 +86,39 @@ class ExperimentBuilder:
     gene_feature_length_uris: List[str]
     gene_feature_length: pd.DataFrame
 
-    def __init__(self, name: str, anndata_cell_filter_spec: AnnDataFilterSpec, gene_feature_length_uris: List[str]):
-        self.name = name
-        self.anndata_cell_filter_spec = anndata_cell_filter_spec
-        self.gene_feature_length_uris = gene_feature_length_uris
+    @classmethod
+    def create(
+        cls, name: str, anndata_cell_filter_spec: AnnDataFilterSpec, gene_feature_length_uris: List[str]
+    ) -> Self:
+        """Factory method. Do not instantiate the class directly."""
+        gene_feature_length = cls._load_gene_feature_length(gene_feature_length_uris)
+        logging.info(f"Loaded gene lengths external reference for {name}, {len(gene_feature_length)} genes.")
+        return cls(name, anndata_cell_filter_spec, gene_feature_length_uris, gene_feature_length)
+
+    @classmethod
+    def _load_gene_feature_length(cls, gene_feature_length_uris: Sequence[str]) -> pd.DataFrame:
+        """
+        Private. Load any external assets required to create the experiment.
+        """
+        return pd.concat(
+            pd.read_csv(
+                io.BytesIO(cat_file(uri)),
+                names=["feature_id", "feature_name", "gene_version", "feature_length"],
+            )
+            .set_index("feature_id")
+            .drop(columns=["feature_name", "gene_version"])
+            for uri in gene_feature_length_uris
+        )
+
+
+class ExperimentBuilder:
+    """
+    Class that embodies the operators and state to build an Experiment.
+    The creation and driving of these objects is done by the main loop.
+    """
+
+    def __init__(self, specification: ExperimentSpecification):
+        self.specification = specification
 
         # accumulated state
         self.n_obs: int = 0
@@ -100,22 +135,17 @@ class ExperimentBuilder:
         self.presence: Dict[int, Tuple[npt.NDArray[np.bool_], npt.NDArray[np.int64]]] = {}
         self.build_completed: bool = False
 
-        self.load_assets()
+    @property
+    def name(self) -> str:
+        return self.specification.name
 
-    def load_assets(self) -> None:
-        """
-        Load any external assets required to create the experiment.
-        """
-        self.gene_feature_length = pd.concat(
-            pd.read_csv(
-                io.BytesIO(cat_file(uri)),
-                names=["feature_id", "feature_name", "gene_version", "feature_length"],
-            )
-            .set_index("feature_id")
-            .drop(columns=["feature_name", "gene_version"])
-            for uri in self.gene_feature_length_uris
-        )
-        logging.info(f"Loaded gene lengths external reference for {self.name}, {len(self.gene_feature_length)} genes.")
+    @property
+    def anndata_cell_filter_spec(self) -> AnnDataFilterSpec:
+        return self.specification.anndata_cell_filter_spec
+
+    @property
+    def gene_feature_length(self) -> pd.DataFrame:
+        return self.specification.gene_feature_length
 
     def create(self, census_data: soma.Collection) -> None:
         """Create experiment within the specified Collection with a single Measurement."""
@@ -260,7 +290,8 @@ class ExperimentBuilder:
         """
         _assert_open_for_write(self.experiment)
 
-        # SOMA does not currently support empty arrays, so special case this corner-case.
+        # SOMA does not currently arrays with a zero length domain, so special case this corner-case
+        # where no data has been read for this experiment.
         if len(self.presence) > 0:
             # sanity check
             assert len(self.presence) == self.n_datasets

--- a/tools/cell_census_builder/tests/conftest.py
+++ b/tools/cell_census_builder/tests/conftest.py
@@ -27,7 +27,7 @@ ORGANISMS = [Organism("homo_sapiens", "NCBITaxon:9606"), Organism("mus_musculus"
 
 
 def get_h5ad(organism: Organism) -> anndata.AnnData:
-    X = np.random.randint(5, size=(4, 4))
+    X = np.random.randint(5, size=(4, 4)).astype(np.float32)
     # The builder only supports sparse matrices
     X = sparse.csr_matrix(X)
 
@@ -54,7 +54,8 @@ def get_h5ad(organism: Organism) -> anndata.AnnData:
             "sex": "test",
             "tissue": "test",
             "organism": "test",
-        }
+        },
+        index=["1", "2", "3", "4"],
     )
     obs = obs_dataframe
 

--- a/tools/cell_census_builder/tests/test_builder.py
+++ b/tools/cell_census_builder/tests/test_builder.py
@@ -9,8 +9,9 @@ import pyarrow as pa
 import tiledb
 import tiledbsoma as soma
 
-from tools.cell_census_builder.__main__ import build, make_experiment_builders
+from tools.cell_census_builder.__main__ import build, make_experiment_specs
 from tools.cell_census_builder.datasets import Dataset
+from tools.cell_census_builder.experiment_builder import ExperimentBuilder
 from tools.cell_census_builder.globals import (
     CENSUS_DATA_NAME,
     CENSUS_INFO_NAME,
@@ -32,7 +33,9 @@ def test_base_builder_creation(
         "tools.cell_census_builder.validate.validate_consolidation", return_value=True
     ):
         # Patching consolidate_tiledb_object, becuase is uses to much memory to run in github actions.
-        experiment_builders = make_experiment_builders()
+        experiment_specifications = make_experiment_specs()
+        experiment_builders = [ExperimentBuilder(spec) for spec in experiment_specifications]
+
         from types import SimpleNamespace
 
         args = SimpleNamespace(multi_process=False, consolidate=True, build_tag="test_tag", max_workers=1, verbose=True)
@@ -42,7 +45,7 @@ def test_base_builder_creation(
         assert return_value == 0
 
         # validate the cell_census
-        return_value = validate(args, soma_path, assets_path, experiment_builders)  # type: ignore[arg-type]
+        return_value = validate(args, soma_path, assets_path, experiment_specifications)  # type: ignore[arg-type]
         assert return_value is True
 
         # Query the census and do assertions

--- a/tools/cell_census_builder/validate.py
+++ b/tools/cell_census_builder/validate.py
@@ -15,11 +15,12 @@ import pyarrow as pa
 import tiledb
 import tiledbsoma as soma
 from scipy import sparse
+from typing_extensions import Self
 
 from .anndata import make_anndata_cell_filter, open_anndata
 from .consolidate import list_uris_to_consolidate
 from .datasets import Dataset
-from .experiment_builder import ExperimentBuilder, reopen_experiment_builders
+from .experiment_builder import ExperimentSpecification
 from .globals import (
     CENSUS_DATA_NAME,
     CENSUS_DATASETS_COLUMNS,
@@ -49,14 +50,23 @@ class EbInfo:
     vars: set[str] = dataclasses.field(default_factory=set)
     dataset_ids: set[str] = dataclasses.field(default_factory=set)
 
-    def update(self: "EbInfo", b: "EbInfo") -> "EbInfo":
+    def update(self: Self, b: Self) -> Self:
         self.n_obs += b.n_obs
         self.vars |= b.vars
         self.dataset_ids |= b.dataset_ids
         return self
 
+    @property
+    def n_vars(self) -> int:
+        return len(self.vars)
 
-def validate_all_soma_objects_exist(soma_path: str, experiment_builders: List[ExperimentBuilder]) -> bool:
+
+def open_experiment(base_uri: str, eb: ExperimentSpecification) -> soma.Experiment:
+    """Helper function that knows the Census schema path conventions."""
+    return soma.Experiment.open(uricat(base_uri, CENSUS_DATA_NAME, eb.name), mode="r")
+
+
+def validate_all_soma_objects_exist(soma_path: str, experiment_specifications: List[ExperimentSpecification]) -> bool:
     """
     Validate all objects present and contain expected metadata.
 
@@ -99,7 +109,7 @@ def validate_all_soma_objects_exist(soma_path: str, experiment_builders: List[Ex
 
         # there should be an experiment for each builder
         census_data = census[CENSUS_DATA_NAME]
-        for eb in experiment_builders:
+        for eb in experiment_specifications:
             assert soma.Experiment.exists(census_data[eb.name].uri)
 
             e = census_data[eb.name]
@@ -113,28 +123,29 @@ def validate_all_soma_objects_exist(soma_path: str, experiment_builders: List[Ex
             rna = e.ms["RNA"]
             assert soma.DataFrame.exists(rna["var"].uri)
             assert soma.Collection.exists(rna["X"].uri)
-            for lyr in CENSUS_X_LAYERS:
-                # layers only exist if there are cells in the measurement
-                if lyr in rna.X:
+
+            # layers and presence exist only if there are cells in the measurement
+            if e.obs.count > 0:
+                for lyr in CENSUS_X_LAYERS:
+                    assert lyr in rna.X
                     assert soma.SparseNDArray.exists(rna.X[lyr].uri)
 
-            # and a dataset presence matrix
-            # dataset presence only exists if there are cells in the measurement
-            if eb.n_obs > 0:
+                # and a dataset presence matrix
                 assert soma.SparseNDArray.exists(rna[FEATURE_DATASET_PRESENCE_MATRIX_NAME].uri)
                 assert sum([c.non_zero_length for c in rna["feature_dataset_presence_matrix"].read().coos()]) > 0
                 # TODO(atolopko): validate 1) shape, 2) joinids exist in datsets and var
+
         return True
 
 
-def _validate_axis_dataframes(args: Tuple[str, str, Dataset, List[ExperimentBuilder]]) -> Dict[str, EbInfo]:
-    assets_path, soma_path, dataset, experiment_builders = args
+def _validate_axis_dataframes(args: Tuple[str, str, Dataset, List[ExperimentSpecification]]) -> Dict[str, EbInfo]:
+    assets_path, soma_path, dataset, experiment_specifications = args
     with soma.Collection.open(soma_path, context=SOMA_TileDB_Context()) as census:
         census_data = census[CENSUS_DATA_NAME]
         dataset_id = dataset.dataset_id
         _, unfiltered_ad = next(open_anndata(assets_path, [dataset], backed="r"))
         eb_info: Dict[str, EbInfo] = {}
-        for eb in experiment_builders:
+        for eb in experiment_specifications:
             eb_info[eb.name] = EbInfo()
             anndata_cell_filter = make_anndata_cell_filter(eb.anndata_cell_filter_spec)
             se = census_data[eb.name]
@@ -167,9 +178,9 @@ def validate_axis_dataframes(
     assets_path: str,
     soma_path: str,
     datasets: List[Dataset],
-    experiment_builders: List[ExperimentBuilder],
+    experiment_specifications: List[ExperimentSpecification],
     args: argparse.Namespace,
-) -> bool:
+) -> Dict[str, EbInfo]:
     """ "
     Validate axis dataframes: schema, shape, contents
 
@@ -182,7 +193,7 @@ def validate_axis_dataframes(
         # check schema
         expected_obs_columns = CENSUS_OBS_TERM_COLUMNS
         expected_var_columns = CENSUS_VAR_TERM_COLUMNS
-        for eb in experiment_builders:
+        for eb in experiment_specifications:
             obs = census_data[eb.name].obs
             var = census_data[eb.name].ms["RNA"].var
             assert sorted(obs.keys()) == sorted(expected_obs_columns.keys())
@@ -193,17 +204,11 @@ def validate_axis_dataframes(
                 assert field.type == expected_var_columns[field.name], f"Unexpected type in {field.name}: {field.type}"
 
     # check shapes & perform weak test of contents
-
-    # clear the TileDBObject instance variables to avoid pickling error
-    for eb in experiment_builders:
-        eb.experiment = None
-        eb.presence = {}
-
-    eb_info = {eb.name: EbInfo() for eb in experiment_builders}
+    eb_info = {eb.name: EbInfo() for eb in experiment_specifications}
     if args.multi_process:
         with create_process_pool_executor(args) as ppe:
             futures = [
-                ppe.submit(_validate_axis_dataframes, (assets_path, soma_path, dataset, experiment_builders))
+                ppe.submit(_validate_axis_dataframes, (assets_path, soma_path, dataset, experiment_specifications))
                 for dataset in datasets
             ]
             for n, future in enumerate(concurrent.futures.as_completed(futures), start=1):
@@ -214,44 +219,43 @@ def validate_axis_dataframes(
     else:
         for n, dataset in enumerate(datasets, start=1):
             for eb_name, ebi in _validate_axis_dataframes(
-                (assets_path, soma_path, dataset, experiment_builders)
+                (assets_path, soma_path, dataset, experiment_specifications)
             ).items():
                 eb_info[eb_name].update(ebi)
             logging.info(f"validate_axis {n} of {len(datasets)} complete.")
 
-    for eb in reopen_experiment_builders(experiment_builders, "r"):
-        assert eb.experiment is not None
-        exp: soma.Experiment = eb.experiment
-        n_vars = len(eb_info[eb.name].vars)
+    for eb in experiment_specifications:
+        with open_experiment(soma_path, eb) as exp:
+            n_vars = len(eb_info[eb.name].vars)
 
-        census_obs_df = exp.obs.read(column_names=["soma_joinid", "dataset_id"]).concat().to_pandas()
-        assert eb_info[eb.name].n_obs == len(census_obs_df)
-        assert (len(census_obs_df) == 0) or (census_obs_df.soma_joinid.max() + 1 == eb_info[eb.name].n_obs)
-        assert eb_info[eb.name].dataset_ids == set(census_obs_df.dataset_id.unique())
+            census_obs_df = exp.obs.read(column_names=["soma_joinid", "dataset_id"]).concat().to_pandas()
+            assert eb_info[eb.name].n_obs == len(census_obs_df)
+            assert (len(census_obs_df) == 0) or (census_obs_df.soma_joinid.max() + 1 == eb_info[eb.name].n_obs)
+            assert eb_info[eb.name].dataset_ids == set(census_obs_df.dataset_id.unique())
 
-        census_var_df = exp.ms["RNA"].var.read(column_names=["feature_id", "soma_joinid"]).concat().to_pandas()
-        assert n_vars == len(census_var_df)
-        assert eb_info[eb.name].vars == set(census_var_df.feature_id.array)
-        assert (len(census_var_df) == 0) or (census_var_df.soma_joinid.max() + 1 == n_vars)
+            census_var_df = exp.ms["RNA"].var.read(column_names=["feature_id", "soma_joinid"]).concat().to_pandas()
+            assert n_vars == len(census_var_df)
+            assert eb_info[eb.name].vars == set(census_var_df.feature_id.array)
+            assert (len(census_var_df) == 0) or (census_var_df.soma_joinid.max() + 1 == n_vars)
 
-        # Validate that all obs soma_joinids are unique and in the range [0, n).
-        obs_unique_joinids = np.unique(census_obs_df.soma_joinid.to_numpy())
-        assert len(obs_unique_joinids) == len(census_obs_df.soma_joinid.to_numpy())
-        assert (len(obs_unique_joinids) == 0) or (
-            (obs_unique_joinids[0] == 0) and (obs_unique_joinids[-1] == (len(obs_unique_joinids) - 1))
-        )
+            # Validate that all obs soma_joinids are unique and in the range [0, n).
+            obs_unique_joinids = np.unique(census_obs_df.soma_joinid.to_numpy())
+            assert len(obs_unique_joinids) == len(census_obs_df.soma_joinid.to_numpy())
+            assert (len(obs_unique_joinids) == 0) or (
+                (obs_unique_joinids[0] == 0) and (obs_unique_joinids[-1] == (len(obs_unique_joinids) - 1))
+            )
 
-        # Validate that all var soma_joinids are unique and in the range [0, n).
-        var_unique_joinids = np.unique(census_var_df.soma_joinid.to_numpy())
-        assert len(var_unique_joinids) == len(census_var_df.soma_joinid.to_numpy())
-        assert (len(var_unique_joinids) == 0) or (
-            (var_unique_joinids[0] == 0) and var_unique_joinids[-1] == (len(var_unique_joinids) - 1)
-        )
+            # Validate that all var soma_joinids are unique and in the range [0, n).
+            var_unique_joinids = np.unique(census_var_df.soma_joinid.to_numpy())
+            assert len(var_unique_joinids) == len(census_var_df.soma_joinid.to_numpy())
+            assert (len(var_unique_joinids) == 0) or (
+                (var_unique_joinids[0] == 0) and var_unique_joinids[-1] == (len(var_unique_joinids) - 1)
+            )
 
-    return True
+    return eb_info
 
 
-def _validate_X_layers_contents_by_dataset(args: Tuple[str, Dataset, List[ExperimentBuilder]]) -> bool:
+def _validate_X_layers_contents_by_dataset(args: Tuple[str, str, Dataset, List[ExperimentSpecification]]) -> bool:
     """
     Validate that a single dataset is correctly represented in the census.
     Intended to be dispatched from validate_X_layers.
@@ -260,58 +264,56 @@ def _validate_X_layers_contents_by_dataset(args: Tuple[str, Dataset, List[Experi
     * the nnz is correct
     * there are no zeros explicitly saved (this is mandated by cell census schema)
     """
-    assets_path, dataset, experiment_builders = args
+    assets_path, soma_path, dataset, experiment_specifications = args
     _, unfiltered_ad = next(open_anndata(assets_path, [dataset]))
 
-    for eb in reopen_experiment_builders(experiment_builders, "r"):
-        assert eb.experiment is not None
-        exp: soma.Experiment = eb.experiment
+    for eb in experiment_specifications:
+        with open_experiment(soma_path, eb) as exp:
+            anndata_cell_filter = make_anndata_cell_filter(eb.anndata_cell_filter_spec)
+            ad = anndata_cell_filter(unfiltered_ad, retain_X=True)
 
-        anndata_cell_filter = make_anndata_cell_filter(eb.anndata_cell_filter_spec)
-        ad = anndata_cell_filter(unfiltered_ad, retain_X=True)
-
-        soma_joinids: npt.NDArray[np.int64] = (
-            exp.obs.read(
-                column_names=["soma_joinid", "dataset_id"], value_filter=f"dataset_id == '{dataset.dataset_id}'"
+            soma_joinids: npt.NDArray[np.int64] = (
+                exp.obs.read(
+                    column_names=["soma_joinid", "dataset_id"], value_filter=f"dataset_id == '{dataset.dataset_id}'"
+                )
+                .concat()
+                .to_pandas()
+                .soma_joinid.to_numpy()
             )
-            .concat()
-            .to_pandas()
-            .soma_joinid.to_numpy()
-        )
 
-        raw_nnz = 0
-        if len(soma_joinids) > 0:
-            assert soma.SparseNDArray.exists(exp.ms["RNA"].X["raw"].uri)
+            raw_nnz = 0
+            if len(soma_joinids) > 0:
+                assert soma.SparseNDArray.exists(exp.ms["RNA"].X["raw"].uri)
 
-            def count_elements(arr: soma.SparseNDArray, join_ids: npt.NDArray[np.int64]) -> int:
-                return sum(t.non_zero_length for t in arr.read((join_ids, slice(None))).coos())
+                def count_elements(arr: soma.SparseNDArray, join_ids: npt.NDArray[np.int64]) -> int:
+                    return sum(t.non_zero_length for t in arr.read((join_ids, slice(None))).coos())
 
-            raw_nnz = count_elements(exp.ms["RNA"].X["raw"], soma_joinids)
+                raw_nnz = count_elements(exp.ms["RNA"].X["raw"], soma_joinids)
 
-        def count_nonzero(arr: Union[sparse.spmatrix, npt.NDArray[Any]]) -> int:
-            """Return _actual_ non-zero count, NOT the stored value count."""
-            if isinstance(arr, (sparse.spmatrix, sparse.coo_array, sparse.csr_array, sparse.csc_array)):
-                return np.count_nonzero(arr.data)
-            return np.count_nonzero(arr)
+            def count_nonzero(arr: Union[sparse.spmatrix, npt.NDArray[Any]]) -> int:
+                """Return _actual_ non-zero count, NOT the stored value count."""
+                if isinstance(arr, (sparse.spmatrix, sparse.coo_array, sparse.csr_array, sparse.csc_array)):
+                    return np.count_nonzero(arr.data)
+                return np.count_nonzero(arr)
 
-        if ad.raw is None:
-            assert raw_nnz == count_nonzero(
-                ad.X
-            ), f"{eb.name}:{dataset.dataset_id} 'raw' nnz mismatch {raw_nnz} vs {count_nonzero(ad.X)}"
-        else:
-            assert raw_nnz == count_nonzero(
-                ad.raw.X
-            ), f"{eb.name}:{dataset.dataset_id} 'raw' nnz mismatch {raw_nnz} vs {count_nonzero(ad.raw.X)}"
+            if ad.raw is None:
+                assert raw_nnz == count_nonzero(
+                    ad.X
+                ), f"{eb.name}:{dataset.dataset_id} 'raw' nnz mismatch {raw_nnz} vs {count_nonzero(ad.X)}"
+            else:
+                assert raw_nnz == count_nonzero(
+                    ad.raw.X
+                ), f"{eb.name}:{dataset.dataset_id} 'raw' nnz mismatch {raw_nnz} vs {count_nonzero(ad.raw.X)}"
 
     return True
 
 
-def _validate_X_layer_has_unique_coords(args: Tuple[ExperimentBuilder, str, int, int]) -> bool:
+def _validate_X_layer_has_unique_coords(args: Tuple[ExperimentSpecification, str, str, int, int]) -> bool:
     """Validate that all X layers have no duplicate coordinates"""
-    experiment_builder, layer_name, row_range_start, row_range_stop = args
-    with soma.Experiment.open(experiment_builder.experiment_uri, context=SOMA_TileDB_Context()) as exp:
+    experiment_specification, soma_path, layer_name, row_range_start, row_range_stop = args
+    with open_experiment(soma_path, experiment_specification) as exp:
         logging.info(
-            f"validate_no_dups_X start, {experiment_builder.name}, {layer_name}, rows [{row_range_start}, {row_range_stop})"
+            f"validate_no_dups_X start, {experiment_specification.name}, {layer_name}, rows [{row_range_start}, {row_range_stop})"
         )
         if layer_name not in exp.ms["RNA"].X:
             return True
@@ -337,8 +339,10 @@ def _validate_X_layer_has_unique_coords(args: Tuple[ExperimentBuilder, str, int,
 
 def validate_X_layers(
     assets_path: str,
+    soma_path: str,
     datasets: List[Dataset],
-    experiment_builders: List[ExperimentBuilder],
+    experiment_specifications: List[ExperimentSpecification],
+    eb_info: Dict[str, EbInfo],
     args: argparse.Namespace,
 ) -> bool:
     """ "
@@ -347,39 +351,27 @@ def validate_X_layers(
     Raises on error.  Returns True on success.
     """
     logging.debug("validate_X_layers")
-    for eb in reopen_experiment_builders(experiment_builders, "r"):
-        assert eb.experiment is not None
-        exp = eb.experiment
+    for eb in experiment_specifications:
+        with open_experiment(soma_path, eb) as exp:
+            assert soma.Collection.exists(exp.ms["RNA"].X.uri)
 
-        assert soma.Collection.exists(exp.ms["RNA"].X.uri)
+            census_obs_df = exp.obs.read(column_names=["soma_joinid"]).concat().to_pandas()
+            n_obs = len(census_obs_df)
+            logging.info(f"uri = {exp.obs.uri}, eb.n_obs = {eb_info[eb.name].n_obs}; n_obs = {n_obs}")
+            assert n_obs == eb_info[eb.name].n_obs
 
-        census_obs_df = exp.obs.read(column_names=["soma_joinid"]).concat().to_pandas()
-        n_obs = len(census_obs_df)
-        logging.info(f"uri = {exp.obs.uri}, eb.n_obs = {eb.n_obs}; n_obs = {n_obs}")
-        # TODO: Only works when run as builder, not standalone validator
-        #  https://github.com/chanzuckerberg/cell-census/issues/179
-        if eb.build_completed:
-            assert eb.n_obs == n_obs
-        census_var_df = exp.ms["RNA"].var.read(column_names=["feature_id", "soma_joinid"]).concat().to_pandas()
-        n_vars = len(census_var_df)
-        # TODO: Only works when run as builder, not standalone validator
-        #  https://github.com/chanzuckerberg/cell-census/issues/179
-        if eb.build_completed:
-            assert eb.n_var == n_vars
+            census_var_df = exp.ms["RNA"].var.read(column_names=["feature_id", "soma_joinid"]).concat().to_pandas()
+            n_vars = len(census_var_df)
+            assert n_vars == eb_info[eb.name].n_vars
 
-        if n_obs > 0:
-            for lyr in CENSUS_X_LAYERS:
-                assert soma.SparseNDArray.exists(exp.ms["RNA"].X[lyr].uri)
-                X = exp.ms["RNA"].X[lyr]
-                assert X.schema.field("soma_dim_0").type == pa.int64()
-                assert X.schema.field("soma_dim_1").type == pa.int64()
-                assert X.schema.field("soma_data").type == CENSUS_X_LAYERS[lyr]
-                assert X.shape == (n_obs, n_vars)
-
-    # clear the TileDBObject instance variables to avoid pickling error
-    for eb in experiment_builders:
-        eb.experiment = None
-        eb.presence = {}
+            if n_obs > 0:
+                for lyr in CENSUS_X_LAYERS:
+                    assert soma.SparseNDArray.exists(exp.ms["RNA"].X[lyr].uri)
+                    X = exp.ms["RNA"].X[lyr]
+                    assert X.schema.field("soma_dim_0").type == pa.int64()
+                    assert X.schema.field("soma_dim_1").type == pa.int64()
+                    assert X.schema.field("soma_data").type == CENSUS_X_LAYERS[lyr]
+                    assert X.shape == (n_obs, n_vars)
 
     if args.multi_process:
         with create_process_pool_executor(args) as ppe:
@@ -387,14 +379,16 @@ def validate_X_layers(
             dup_coord_futures = [
                 ppe.submit(
                     _validate_X_layer_has_unique_coords,
-                    (eb, layer_name, row_start, row_start + ROWS_PER_PROCESS),
+                    (eb, soma_path, layer_name, row_start, row_start + ROWS_PER_PROCESS),
                 )
-                for eb in experiment_builders
+                for eb in experiment_specifications
                 for layer_name in CENSUS_X_LAYERS
                 for row_start in range(0, n_obs, ROWS_PER_PROCESS)
             ]
             per_dataset_futures = [
-                ppe.submit(_validate_X_layers_contents_by_dataset, (assets_path, dataset, experiment_builders))
+                ppe.submit(
+                    _validate_X_layers_contents_by_dataset, (assets_path, soma_path, dataset, experiment_specifications)
+                )
                 for dataset in datasets
             ]
             for n, future in enumerate(concurrent.futures.as_completed(dup_coord_futures), start=1):
@@ -407,13 +401,13 @@ def validate_X_layers(
                 logging.info(f"validate_X {n} of {len(datasets)} complete.")
 
     else:
-        for eb in experiment_builders:
+        for eb in experiment_specifications:
             for layer_name in CENSUS_X_LAYERS:
                 logging.info(f"Validating no duplicate coordinates in X layer {eb.name} layer {layer_name}")
-                assert _validate_X_layer_has_unique_coords((eb, layer_name, 0, n_obs))
+                assert _validate_X_layer_has_unique_coords((eb, soma_path, layer_name, 0, n_obs))
         for n, vld in enumerate(
             (
-                _validate_X_layers_contents_by_dataset((assets_path, dataset, experiment_builders))
+                _validate_X_layers_contents_by_dataset((assets_path, soma_path, dataset, experiment_specifications))
                 for dataset in datasets
             ),
             start=1,
@@ -445,7 +439,7 @@ def validate_manifest_contents(assets_path: str, datasets: List[Dataset]) -> boo
     return True
 
 
-def validate_consolidation(soma_path: str, experiment_builders: List[ExperimentBuilder]) -> bool:
+def validate_consolidation(soma_path: str, experiment_specifications: List[ExperimentSpecification]) -> bool:
     """Verify that obs, var and X layers are all fully consolidated & vacuumed"""
 
     def is_empty_tiledb_array(uri: str) -> bool:
@@ -495,7 +489,7 @@ def validate_relative_path(soma_path: str) -> bool:
 
 
 def validate(
-    args: argparse.Namespace, soma_path: str, assets_path: str, experiment_builders: List[ExperimentBuilder]
+    args: argparse.Namespace, soma_path: str, assets_path: str, experiment_specifications: List[ExperimentSpecification]
 ) -> bool:
     """
     Validate that the "census" matches the datasets and experiment builder spec.
@@ -505,22 +499,14 @@ def validate(
     logging.info("Validation start")
     assert validate_directory_structure(soma_path, assets_path)
 
-    # HACK: experiment_uri is only initialized in create(), which is only called if census is built before calling
-    # the validator; fails in validator-only mode
-    # TODO: This should be handled more elegantly, say, by initializing
-    #  in the ExperimentBuilder constructor. https://github.com/chanzuckerberg/cell-census/issues/179
-    for eb in experiment_builders:
-        if not eb.build_completed:
-            eb.experiment_uri = f"{soma_path}/{CENSUS_DATA_NAME}/{eb.name}"
-
     assert soma_path.endswith("soma") and assets_path.endswith("h5ads")
-    assert validate_all_soma_objects_exist(soma_path, experiment_builders)
+    assert validate_all_soma_objects_exist(soma_path, experiment_specifications)
     assert validate_relative_path(soma_path)
     datasets = load_datasets_from_census(assets_path, soma_path)
     assert validate_manifest_contents(assets_path, datasets)
 
-    assert validate_axis_dataframes(assets_path, soma_path, datasets, experiment_builders, args)
-    assert validate_X_layers(assets_path, datasets, experiment_builders, args)
-    assert validate_consolidation(soma_path, experiment_builders)
+    assert (eb_info := validate_axis_dataframes(assets_path, soma_path, datasets, experiment_specifications, args))
+    assert validate_X_layers(assets_path, soma_path, datasets, experiment_specifications, eb_info, args)
+    assert validate_consolidation(soma_path, experiment_specifications)
     logging.info("Validation finished (success)")
     return True

--- a/tools/scripts/requirements.txt
+++ b/tools/scripts/requirements.txt
@@ -18,3 +18,4 @@ Cython  # required by owlready2
 wheel  # required by owlready2
 owlready2
 gitpython
+attrs


### PR DESCRIPTION
Fixes #215 
Fixes #179 

Changes:
* Break the ExperimentBuilder into two parts:
    * ExperimentSpecification - read-only declaration of Experiment configuration.  May not contain information derived from the AnnData files.
    * ExperimentBuilder - the accumulated state used during the build process, derived from AnnData input files.
* Refactor the validator to _only_ use the ExperimentSpecifications, increasing isolation from the build process. As a side effect, this fixes #179
* Minor fixes to test_builder which was incorrectly creating AnnData's (this cleans up all of the warnings generated during the test execution)
* Added `attrs` dependency (preferred over dataclasses, and used to create ExperimentSpecification)

