### PR TITLE
add unit tests for python cell_census package

### DIFF
--- a/api/python/cell_census/tests/test_directory.py
+++ b/api/python/cell_census/tests/test_directory.py
@@ -33,6 +33,9 @@ DIRECTORY_JSON = {
             "s3_region": "us-west-2",
         },
     },
+    # An explicitly dangling tag, to confirm we handle correct
+    # Underscore indicates expected failure to test below
+    "_dangling": "no-such-tag",
 }
 
 
@@ -50,7 +53,7 @@ def test_get_census_version_directory(directory_mock: Any) -> None:
     assert all((type(v) == dict for v in directory.values()))
 
     for tag in DIRECTORY_JSON:
-        assert tag in directory
+        assert tag[0] == '_' or tag in directory
         if isinstance(DIRECTORY_JSON[tag], dict):
             assert directory[tag] == DIRECTORY_JSON[tag]
 
@@ -58,6 +61,11 @@ def test_get_census_version_directory(directory_mock: Any) -> None:
 
     for tag in directory:
         assert directory[tag] == cell_census.get_census_version_description(tag)
+
+
+def test_get_census_version_description_errors() -> None:
+    with pytest.raises(KeyError):
+        cell_census.get_census_version_description(census_version="no/such/version/exists")
 
 
 @pytest.mark.live_corpus

--- a/api/python/cell_census/tests/test_directory.py
+++ b/api/python/cell_census/tests/test_directory.py
@@ -53,7 +53,7 @@ def test_get_census_version_directory(directory_mock: Any) -> None:
     assert all((type(v) == dict for v in directory.values()))
 
     for tag in DIRECTORY_JSON:
-        assert tag[0] == '_' or tag in directory
+        assert tag[0] == "_" or tag in directory
         if isinstance(DIRECTORY_JSON[tag], dict):
             assert directory[tag] == DIRECTORY_JSON[tag]
 

--- a/api/python/cell_census/tests/test_get_helpers.py
+++ b/api/python/cell_census/tests/test_get_helpers.py
@@ -36,3 +36,5 @@ def test_get_presence_matrix(organism: str) -> None:
     assert pm.shape[1] == len(
         census["census_data"][organism].ms["RNA"].var.read(column_names=["soma_joinid"]).concat().to_pandas()
     )
+
+    census.close()

--- a/api/python/cell_census/tests/test_open.py
+++ b/api/python/cell_census/tests/test_open.py
@@ -1,4 +1,5 @@
 import pathlib
+import time
 
 import anndata
 import numpy as np
@@ -24,6 +25,39 @@ def test_open_soma_latest() -> None:
 
 
 @pytest.mark.live_corpus
+def test_open_soma_with_context() -> None:
+    description = cell_census.get_census_version_description("latest")
+    uri = description["soma"]["uri"]
+    s3_region = description["soma"].get("s3_region")
+    assert s3_region == "us-west-2"
+
+    # Verify the default region is set correctly in the TileDB context object.
+    with cell_census.open_soma(census_version="latest", context=soma.SOMATileDBContext()) as census:
+        assert census.context.tiledb_ctx.config()["vfs.s3.region"] == s3_region
+
+    # Verify that config provided is passed through correctly
+    soma_init_buffer_bytes = "221000"
+    timestamp = int(time.time() * 1000) - 10  # don't use exactly current time, as that is the default
+    cfg = {
+        "timestamp": timestamp,
+        "tiledb_config": {
+            "soma.init_buffer_bytes": soma_init_buffer_bytes,
+            "vfs.s3.region": s3_region,
+        },
+    }
+    context = soma.SOMATileDBContext().replace(**cfg)
+    with cell_census.open_soma(uri=uri, context=context) as census:
+        assert census.uri == uri
+        assert census.context.tiledb_ctx.config()["soma.init_buffer_bytes"] == soma_init_buffer_bytes
+        assert census.context.timestamp == timestamp
+
+
+def test_open_soma_errors() -> None:
+    with pytest.raises(ValueError):
+        cell_census.open_soma(census_version=None)
+
+
+@pytest.mark.live_corpus
 def test_get_source_h5ad_uri() -> None:
     with cell_census.open_soma(census_version="latest") as census:
         census_datasets = census["census_info"]["datasets"].read().concat().to_pandas()
@@ -37,16 +71,42 @@ def test_get_source_h5ad_uri() -> None:
         assert locator["uri"].endswith(a_dataset.dataset_h5ad_path)
 
 
-@pytest.mark.live_corpus
-def test_download_source_h5ad(tmp_path: pathlib.Path) -> None:
+def test_get_source_h5ad_uri_errors() -> None:
+    with pytest.raises(KeyError):
+        cell_census.get_source_h5ad_uri(dataset_id="no/such/id")
+
+
+@pytest.fixture
+def small_dataset_id() -> str:
     with cell_census.open_soma(census_version="latest") as census:
         census_datasets = census["census_info"]["datasets"].read().concat().to_pandas()
 
     small_dataset = census_datasets.nsmallest(1, "dataset_total_cell_count").iloc[0]
+    assert isinstance(small_dataset.dataset_id, str)
+    return small_dataset.dataset_id
+
+
+@pytest.mark.live_corpus
+def test_download_source_h5ad(tmp_path: pathlib.Path, small_dataset_id: str) -> None:
+    # with cell_census.open_soma(census_version="latest") as census:
+    #     census_datasets = census["census_info"]["datasets"].read().concat().to_pandas()
+
+    # small_dataset = census_datasets.nsmallest(1, "dataset_total_cell_count").iloc[0]
 
     adata_path = tmp_path / "adata.h5ad"
-    cell_census.download_source_h5ad(small_dataset.dataset_id, adata_path.as_posix(), census_version="latest")
+    cell_census.download_source_h5ad(small_dataset_id, adata_path.as_posix(), census_version="latest")
     assert adata_path.exists() and adata_path.is_file()
-
     ad = anndata.read_h5ad(adata_path.as_posix())
     assert ad is not None
+
+
+def test_download_source_h5ad_errors(tmp_path: pathlib.Path, small_dataset_id: str) -> None:
+    existing_file = tmp_path / "existing_file.h5ad"
+    existing_file.touch()
+    assert existing_file.exists()
+
+    with pytest.raises(ValueError):
+        cell_census.download_source_h5ad(small_dataset_id, existing_file.as_posix(), census_version="latest")
+
+    with pytest.raises(ValueError):
+        cell_census.download_source_h5ad(small_dataset_id, "/tmp/dirname/", census_version="latest")

--- a/api/python/cell_census/tests/test_open.py
+++ b/api/python/cell_census/tests/test_open.py
@@ -88,11 +88,6 @@ def small_dataset_id() -> str:
 
 @pytest.mark.live_corpus
 def test_download_source_h5ad(tmp_path: pathlib.Path, small_dataset_id: str) -> None:
-    # with cell_census.open_soma(census_version="latest") as census:
-    #     census_datasets = census["census_info"]["datasets"].read().concat().to_pandas()
-
-    # small_dataset = census_datasets.nsmallest(1, "dataset_total_cell_count").iloc[0]
-
     adata_path = tmp_path / "adata.h5ad"
     cell_census.download_source_h5ad(small_dataset_id, adata_path.as_posix(), census_version="latest")
     assert adata_path.exists() and adata_path.is_file()

--- a/api/python/cell_census/tests/test_open.py
+++ b/api/python/cell_census/tests/test_open.py
@@ -37,9 +37,9 @@ def test_open_soma_with_context() -> None:
 
     # Verify that config provided is passed through correctly
     soma_init_buffer_bytes = "221000"
-    timestamp = int(time.time() * 1000) - 10  # don't use exactly current time, as that is the default
+    timestamp_ms = int(time.time() * 1000) - 10  # don't use exactly current time, as that is the default
     cfg = {
-        "timestamp": timestamp,
+        "timestamp": timestamp_ms,
         "tiledb_config": {
             "soma.init_buffer_bytes": soma_init_buffer_bytes,
             "vfs.s3.region": s3_region,
@@ -49,7 +49,7 @@ def test_open_soma_with_context() -> None:
     with cell_census.open_soma(uri=uri, context=context) as census:
         assert census.uri == uri
         assert census.context.tiledb_ctx.config()["soma.init_buffer_bytes"] == soma_init_buffer_bytes
-        assert census.context.timestamp == timestamp
+        assert census.context.timestamp_ms == timestamp_ms
 
 
 def test_open_soma_errors() -> None:

--- a/api/python/cell_census/tests/test_util.py
+++ b/api/python/cell_census/tests/test_util.py
@@ -17,3 +17,5 @@ def test_uri_join() -> None:
     assert _uri_join("/foo/bar", "a") == "/foo/a"
     assert _uri_join("file://foo/bar", "a") == "file://foo/a"
     assert _uri_join("file:///foo/bar", "a") == "file:///foo/a"
+
+    assert _uri_join("https://foo/bar", "https://a/b") == "https://a/b"


### PR DESCRIPTION
Changes - more/better unit tests for the cell_census python package:
* add error condition unit test coverage for `open_soma` and other API
* add tests to cover all `open_soma` parameters
* add missing absolute URI test for `uri_join`
