### PR TITLE
assertion to confirm correct MP configuration

### DIFF
--- a/tools/cell_census_builder/mp.py
+++ b/tools/cell_census_builder/mp.py
@@ -1,6 +1,7 @@
 import argparse
 import concurrent.futures
 import logging
+import multiprocessing
 import os
 from typing import Optional, cast
 
@@ -26,6 +27,11 @@ def process_initializer(verbose: int = 0) -> None:
 def create_process_pool_executor(
     args: argparse.Namespace, max_workers: Optional[int] = None
 ) -> concurrent.futures.ProcessPoolExecutor:
+    # We rely on the pool configuration being correct. Failure to do this will
+    # lead to strange errors on some OS (eg., Linux defaults to fork). Rather
+    # than chase those bugs, assert correct configuration.
+    assert multiprocessing.get_start_method(True) == "spawn"
+
     return concurrent.futures.ProcessPoolExecutor(
         max_workers=args.max_workers if max_workers is None else max_workers,
         initializer=process_initializer,


### PR DESCRIPTION
Adding assertion to the process pool creation utility to confirm that the system is correctly configured. This will prevent chasing of obscure bugs on systems which default to `fork` rather than `spawn`