### PR TITLE
fix email address in Python package metadata

### DIFF
--- a/api/python/cell_census/pyproject.toml
+++ b/api/python/cell_census/pyproject.toml
@@ -7,7 +7,7 @@ name = "cell_census"
 dynamic = ["version"]
 description = "API to simplify use of the CZI Science CELLxGENE Cell Census"
 authors = [
-    { name = "Chan Zuckerberg Initiative", email = "cellxgene@chanzuckerberg.com" }
+    { name = "Chan Zuckerberg Initiative", email = "soma@chanzuckerberg.com" }
 ]
 license = { text = "MIT" }
 readme = "README.md"


### PR DESCRIPTION
Partial fix for #280 

This fixes package metadata for the Python cell-census package.