### PR TITLE
Pablo gar/add notebook guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ The Cell Census is a data object publicly hosted online and a convenience API to
 
 ## Cell Census data releases
 
-Starting in  mid 2023, Cell Census long-term supported data builds will be released every 6 months and will be publicly accessible for at least 5 years after release. 
+The Cell Census data release plans are detailed [here](./docs/cell_census_data_release_info). 
 
-In between long-term supported data build releases, weekly builds will be released without any guarantee of permanence. 
+Shortly, starting in mid 2023 Cell Census long-term supported data releases will be publish every 6 months and will be publicly accessible for at least 5 years. In addition, weekly releases will be published without any guarantee of permanence. 
 
 ## Cell Census data organization
 

--- a/docs/cell_census_data_release_info.md
+++ b/docs/cell_census_data_release_info.md
@@ -1,0 +1,23 @@
+# Cell Census data releases 
+
+**Last edited**: March, 2023.
+
+## What is a Cell Census data release?
+
+It is a Cell Census build that is publicly hosted online. A Cell Census build is 
+a [TileDB-SOMA](https://github.com/single-cell-data/TileDB-SOMA) collection with the Cell Census data from [CZ CELLxGENE Discover](https://cellxgene.cziscience.com/) as specified in the [Cell Census schema](https://github.com/chanzuckerberg/cell-census/blob/main/docs/cell_census_schema.md#data-encoding-and-organization). 
+
+### Long-term supported Cell Census release (LTS)
+
+To enable data stability and scientific reproducibility, [CZ CELLxGENE Discover](https://cellxgene.cziscience.com/) plans to perform regular LTS Cell Census data releases:
+
+* Published online every six months for public access.
+* Available for public access for at least 5 years upon publication.
+ 
+
+### Weekly Cell Census release (latest)
+
+[CZ CELLxGENE Discover](https://cellxgene.cziscience.com/) ingests a handful of new datasets every week. To quickly enable access to these new data via the Cell Census,  [CZ CELLxGENE Discover](https://cellxgene.cziscience.com/) plans to perform weekly Cell Census data releases:
+
+* Published online every Monday for public access, except for CZI holidays. 
+* Available for public access for 1 week or until the next latest release is performed, whichever is the longest.

--- a/docs/cell_census_notebook_guidelines.md
+++ b/docs/cell_census_notebook_guidelines.md
@@ -1,0 +1,29 @@
+# Cell Census API notebook/vignette guidelines
+
+API demonstration code that is part of the documentation should be deposited here: 
+
+- Python notebooks [`cell-census/api/python/notebooks`](https://github.com/chanzuckerberg/cell-census/tree/main/api/python/notebooks)
+- R vignettes [`cell-census/api/r/CellCensus/vignettes`](https://github.com/chanzuckerberg/cell-census/tree/main/api/r/CellCensus/vignettes)
+
+
+Since these assets are user-facing and are one of the main form users get onboarded with the product, then the following guidelines need to be followed to ensure readability and a consistent experience.
+
+## Guidelines
+
+### Title
+
+* It must use the highest-level markdown header `#`.
+* Unless needed it, it should not contain the feature name in it.
+* It should be concise, self-explanatory and if possible indicate an action.
+
+Examples:
+
+:white_check_mark: `# Exploring all data from a tissue.`
+:white_check_mark: `# Query and extract slices of data.`
+
+:x: `# Census datasets presence` *not self-explanatory, has "Census" in it.*
+:x: `# Normalizing full-length gene sequencing data from the Cell Censuse` *it has "Census" in it.*
+
+
+
+## Examples 

--- a/docs/cell_census_notebook_guidelines.md
+++ b/docs/cell_census_notebook_guidelines.md
@@ -41,7 +41,7 @@ Examples:
 
 > This notebook provides a demonstration for integrating two Cell Census datasets using scvi-tools. The goal is not to provide an exhaustive guide on proper integration, but to showcase what information in the Cell Census can inform data integration.
 
-:white_check_mark: *it contains a long explanation of what the Cell Census is, and the goal is not clear *
+:x: *it contains a long explanation of what the Cell Census is, and the goal is not clear*
 
 > The Cell Census is a versioned container for the single-cell data hosted at CELLxGENE Discover. The Cell Census utilizes SOMA powered by TileDB for storing, accessing, and efficiently filtering data.
 >

--- a/docs/cell_census_notebook_guidelines.md
+++ b/docs/cell_census_notebook_guidelines.md
@@ -60,10 +60,10 @@ Example:
 :white_check_mark:
 
 > 1. Learning about the lung data.
->  1. Learning about cells of lung data.
->  1. Learning about genes of lung data.
-> 1. Fetching all human lung data from the Cell Census.
-> 1. Obtaining QC metrics for this data slice.
+>    2. Learning about cells of lung data.
+>    3. Learning about genes of lung data.
+> 2. Fetching all human lung data from the Cell Census.
+> 3. Obtaining QC metrics for this data slice.
 
 ### Sections
 

--- a/docs/cell_census_notebook_guidelines.md
+++ b/docs/cell_census_notebook_guidelines.md
@@ -51,13 +51,13 @@ Examples:
 
 Immediately after the the introduction a table of contents must be provided:
 
-* It must be followed by the bolded word **Contents:**. 
+* It must be followed by the bolded word "**Contents:**" . 
 * It must contain an ordered list of the second-level headers (`##`) used for [Sections](#Sections).
 * If necessary it may contain sub-bullets corresponding to lower-level headers (`###`, etc)
 
 Example:
 
-:whitecheckmark:
+:white_check_mark:
 
 > 1. Learning about the lung data.
 >  1. Learning about cells of lung data.

--- a/docs/cell_census_notebook_guidelines.md
+++ b/docs/cell_census_notebook_guidelines.md
@@ -60,8 +60,6 @@ Example:
 :white_check_mark:
 
 > 1. Learning about the lung data.
->    2. Learning about cells of lung data.
->    3. Learning about genes of lung data.
 > 2. Fetching all human lung data from the Cell Census.
 > 3. Obtaining QC metrics for this data slice.
 

--- a/docs/cell_census_notebook_guidelines.md
+++ b/docs/cell_census_notebook_guidelines.md
@@ -6,17 +6,15 @@ API demonstration code that is part of the documentation should be deposited her
 - R vignettes [`cell-census/api/r/CellCensus/vignettes`](https://github.com/chanzuckerberg/cell-census/tree/main/api/r/CellCensus/vignettes)
 
 
-Since these assets are user-facing and are automatically rendered to the doc-sites, they are one of the main form users get onboarded on the product. 
-
-The following guidelines need to be followed to ensure readability and a consistent experience.
+These assets are user-facing and are automatically rendered to the doc-sites, they are one of the main form users get onboarded on the product. Thus the following guidelines need to be followed to ensure readability and a consistent experience.
 
 ## Guidelines
 
 ### Title
 
 * It must use the highest-level markdown header `#`.
-* Unless needed it, it should not contain the "Cell Census" in it.
-* It should be concise, self-explanatory and if possible indicate an action.
+* Unless needed it, it should not contain "Cell Census" in it.
+* It should be concise, self-explanatory, and if possible indicate an action.
 
 Examples:
 
@@ -47,33 +45,35 @@ Examples:
 >
 >This notebook shows you how to learn about the Cell Census contents and how to query it.
 
-### TOC 
+### Table of Contents 
 
 Immediately after the the introduction a table of contents must be provided:
 
-* It must be followed by the bolded word "**Contents:**" . 
+* It must be placed under the bolded word "**Contents**" . 
 * It must contain an ordered list of the second-level headers (`##`) used for [Sections](#Sections).
-* If necessary it may contain sub-bullets corresponding to lower-level headers (`###`, etc)
+* If necessary it may contain sub-lists corresponding to lower-level headers (`###`, etc)
 
 Example:
 
 :white_check_mark:
 
+> **Contents**
+> 
 > 1. Learning about the lung data.
 > 2. Fetching all human lung data from the Cell Census.
 > 3. Obtaining QC metrics for this data slice.
 
 ### Sections
 
-Content must be organized within sections:
+The rest of the notebook/vignette content must be organized within sections:
 
-* The section title must use the second-level markdown header `##`. **This is important as the python doc-site renders these in the side bar and in the full view of all notebooks.**
-* The section title should be concise, self-explanatory and if possible indicate an action.
-* The section's contents and presence/absence of sub-headers is left to the discretion of the writer
-* The section's non-code context should be kept as succinct as possible.
+* The section title must use the second-level markdown header `##`. **This is important as the python doc-site renders these in the sidebar and in the full view of all notebooks.**
+* The section title should be concise, self-explanatory, and if possible indicate an action.
+* The section's contents and presence or absence of sub-headers are left to the discretion of the writer.
+* The section's non-code content should be kept as succinct as possible.
 
 
-## Example notebook/vignette. 
+## Example notebook/vignette 
 
 ```
 # Integration of data from the Cell Census
@@ -83,7 +83,7 @@ Cell Census datasets using `scvi-tools`. The goal is not to
 provide an exhaustive guide on proper integration, but to showcase 
 what information in the Cell Census can inform data integration.
 
-**Contents:**
+**Contents**
 
 1. Finding and fetching data from mouse liver.
 2. Gene-length normalization of Smart-Seq2 data.
@@ -98,17 +98,17 @@ what information in the Cell Census can inform data integration.
 Let's load all modules needed for this notebook.
 
 \code
-	import cell_census
-	import scanpy as sc
-	import numpy as np
-	import scvi
-	from scipy.sparse import csr_matrix
+  import cell_census
+  import scanpy as sc
+  import numpy as np
+  import scvi
+  from scipy.sparse import csr_matrix
 \code 
 
 Now we can open the Cell Census 
 
 \code 
-	census = cell_census.open_soma(census_version="latest")
+  census = cell_census.open_soma(census_version="latest")
 \code
 
 In this notebook we will use Tabula Muris Senis data 

--- a/docs/cell_census_notebook_guidelines.md
+++ b/docs/cell_census_notebook_guidelines.md
@@ -1,4 +1,4 @@
-# Cell Census API notebook/vignette guidelines
+# Cell Census API notebook/vignette editorial guidelines
 
 API demonstration code that is part of the documentation should be deposited here: 
 
@@ -6,14 +6,16 @@ API demonstration code that is part of the documentation should be deposited her
 - R vignettes [`cell-census/api/r/CellCensus/vignettes`](https://github.com/chanzuckerberg/cell-census/tree/main/api/r/CellCensus/vignettes)
 
 
-Since these assets are user-facing and are one of the main form users get onboarded with the product, then the following guidelines need to be followed to ensure readability and a consistent experience.
+Since these assets are user-facing and are automatically rendered to the doc-sites, they are one of the main form users get onboarded on the product. 
+
+The following guidelines need to be followed to ensure readability and a consistent experience.
 
 ## Guidelines
 
 ### Title
 
 * It must use the highest-level markdown header `#`.
-* Unless needed it, it should not contain the feature name in it.
+* Unless needed it, it should not contain the "Cell Census" in it.
 * It should be concise, self-explanatory and if possible indicate an action.
 
 Examples:
@@ -24,8 +26,100 @@ Examples:
 
 :x: `# Census datasets presence` *not self-explanatory, has "Census" in it.*
 
-:x: `# Normalizing full-length gene sequencing data from the Cell Censuse` *it has "Census" in it.*
+:x: `# Normalizing full-length gene sequencing data from the Cell Census` *has "Census" in it.*
+
+### Introduction
+
+Introductory text must be included right underneath the title.
+
+* It must provide a one paragraph summary of the notebook's goals.
+* It must not contain an explanation of the Cell Census.
+
+Examples: 
+
+:white_check_mark:
+
+> This notebook provides a demonstration for integrating two Cell Census datasets using scvi-tools. The goal is not to provide an exhaustive guide on proper integration, but to showcase what information in the Cell Census can inform data integration.
+
+:white_check_mark: *it contains a long explanation of what the Cell Census is, and the goal is not clear *
+
+> The Cell Census is a versioned container for the single-cell data hosted at CELLxGENE Discover. The Cell Census utilizes SOMA powered by TileDB for storing, accessing, and efficiently filtering data.
+>
+>This notebook shows you how to learn about the Cell Census contents and how to query it.
+
+### TOC 
+
+Immediately after the the introduction a table of contents must be provided:
+
+* It must be followed by the bolded word **Contents:**. 
+* It must contain an ordered list of the second-level headers (`##`) used for [Sections](#Sections).
+* If necessary it may contain sub-bullets corresponding to lower-level headers (`###`, etc)
+
+Example:
+
+:whitecheckmark:
+
+> 1. Learning about the lung data.
+>  1. Learning about cells of lung data.
+>  1. Learning about genes of lung data.
+> 1. Fetching all human lung data from the Cell Census.
+> 1. Obtaining QC metrics for this data slice.
+
+### Sections
+
+Content must be organized within sections:
+
+* The section title must use the second-level markdown header `##`. **This is important as the python doc-site renders these in the side bar and in the full view of all notebooks.**
+* The section title should be concise, self-explanatory and if possible indicate an action.
+* The section's contents and presence/absence of sub-headers is left to the discretion of the writer
+* The section's non-code context should be kept as succinct as possible.
 
 
+## Example notebook/vignette. 
 
-## Examples 
+```
+# Integration of data from the Cell Census
+
+This notebook provides a demonstration for integrating two 
+Cell Census datasets using `scvi-tools`. The goal is not to 
+provide an exhaustive guide on proper integration, but to showcase 
+what information in the Cell Census can inform data integration.
+
+**Contents:**
+
+1. Finding and fetching data from mouse liver.
+2. Gene-length normalization of Smart-Seq2 data.
+3. Integration with scvi-tools.
+   1. Inspecting data prior to integration.
+   2. Integration with batch defined as dataset_id.
+   3. Integration with batch defined as dataset_id + donor_id.
+   4. Integration with batch defined as dataset_id + donor_id + assay_ontology_term_id + suspension_type.
+
+## Finding and fetching data from mouse liver
+
+Let's load all modules needed for this notebook.
+
+\code
+	import cell_census
+	import scanpy as sc
+	import numpy as np
+	import scvi
+	from scipy.sparse import csr_matrix
+\code 
+
+Now we can open the Cell Census 
+
+\code 
+	census = cell_census.open_soma(census_version="latest")
+\code
+
+In this notebook we will use Tabula Muris Senis data 
+from the liver as it contains cells from both 10X 
+Genomics and Smart-Seq2 technologies.
+
+Let's query the datasets table of the Cell Census by 
+filtering on collection_name for "Tabula Muris Senis" 
+and dataset_title for "liver".
+
+[...]
+```

--- a/docs/cell_census_notebook_guidelines.md
+++ b/docs/cell_census_notebook_guidelines.md
@@ -19,9 +19,11 @@ Since these assets are user-facing and are one of the main form users get onboar
 Examples:
 
 :white_check_mark: `# Exploring all data from a tissue.`
+
 :white_check_mark: `# Query and extract slices of data.`
 
 :x: `# Census datasets presence` *not self-explanatory, has "Census" in it.*
+
 :x: `# Normalizing full-length gene sequencing data from the Cell Censuse` *it has "Census" in it.*
 
 

--- a/docs/cell_census_storage_and_release_policy.md
+++ b/docs/cell_census_storage_and_release_policy.md
@@ -1,45 +1,48 @@
 # Cell Census storage & release policy
 
-**Last edited**: Dec, 2022.
+**Last edited**: March, 2023.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED" "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP 14](https://tools.ietf.org/html/bcp14), [RFC2119](https://www.rfc-editor.org/rfc/rfc2119.txt), and [RFC8174](https://www.rfc-editor.org/rfc/rfc8174.txt) when, and only when, they appear in all capitals, as shown here.
 
----
+## Definitions
 
-The cell census MUST be stored in the following S3 root bucket:
+* **Cell Census build**: a SOMA collection with the Cell Census data [as specified in the Cell Census schema](https://github.com/chanzuckerberg/cell-census/blob/main/docs/cell_census_schema.md#data-encoding-and-organization). 
+* **Cell Census source H5AD files**: the set of H5AD files used to create a Cell Census build.
+* **Cell Census release**: a Cell Census build that is publicly hosted online.
+* **Cell Census release `tag`**:  a label for a Cell Census release, it MUST be a string of printable ASCII characters.
+
+## Cell Census data storage policy
+
+The following S3 bucket MUST be used as the root to store Cell Census data:
 
 `s3://cellxgene-data-public/`
 
-All contents of a Cell Census build data MUST be deposited in a folder named `cell-census`: 
+Cell Census data MUST be deposited under a folder named `cell-census` of the root S3 bucket:
+ 
+ `./cell-census`
+ 
+All data related to a Cell Census **release** MUST be deposited in a folder named with the **tag** of the release:
 
-`./cell-census/`
+ `./cell-census/[tag]/`
 
-This folder MUST contain all public builds and releases defined as:
+The Cell Census **release** MUST be deposited in a folder named `soma`:
 
-* Census "build" is a SOMA collection / container containing cell data.
-* Census "RELEASE" is a "build" which has been officially blessed and released in a formal manner.
-* A "build" is named with a `tag`, which is a string of printable ASCII (eg, "foo", "2022-11-01", "1-rc2.9"):
-   `./cell-census/[tag]/`
-* a RELEASE is named with a tag following the conventional format `release-[counter]`:
-   `./cell-census/release-[counter]/`
+`./cell-census/[tag]/soma/`
 
-The Cell Census SOMA-related files MUST be deposited within the release folder on a folder named `soma`:
+All Cell Census **source h5ads** used to create a specific Cell Census **release** MUST be copied into a folder named `h5ads`:	
+`./cell-census/[tag]/h5ads/`
 
-`./cell-census/release-[counter]/soma/`
+## Cell Census release information `json`
 
-All h5ads used to create the Cell Census MUST be copied within the release folder into a folder named `h5ads`:	
-`./cell-census/release-[counter]/h5ads/`
 
-Any dataset changes, additions, or deletions per release MUST be documented in the following human-readable changelog file name `changelog.txt`:
-
-`./cell-census/changelog.txt`
-
-The publication date along with the full URI paths for the `soma` folder and the `h5ads` folder  for all Cell Census releases  MUST be recorded in a `json` file with the following naming convention and structure, which will be used as a machine- and human-readable directory of available census builds:
+The publication date along with the full URI paths for the `soma` folder and the `h5ads` folder for all Cell Census releases  MUST be recorded in a `json` file with the following naming convention and structure, which will be used as a machine- and human-readable directory of available census builds:
 
 
 `./cell-census/releases.json`
 
-This file MUST be in `json` formats where the parent keys are release identifiers (alias or name). The alias `"latest"` MUST be present. This `json` file MUST follow this schema:
+* This file MUST be in `json` formats where the parent keys are release identifiers (alias or name). 
+* The alias `latest` MUST be present and MUST point to the **Weekly Cell Census release**. 
+* The prefix `V` MUST be used followed by an integer counter to label long-term supported Cell Census releases, e.g. `V1`.
 
 
 ```


### PR DESCRIPTION
Adds a document with a set of editorial guidelines for notebooks (python) and vignettes (R). 

An audit of the existing assets must follow upon approval of this PR.